### PR TITLE
feat: Redesign PC character creation template interface

### DIFF
--- a/.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec-lite.md
+++ b/.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec-lite.md
@@ -1,0 +1,3 @@
+# Spec Summary (Lite)
+
+Enhance the existing CampaignSeederService to automatically copy all Character records from the Master Campaign when a new campaign is created, providing gamemasters with immediate access to established NPCs and example enemies. This utilizes the existing CharacterDuplicator service and executes automatically during campaign creation without user intervention.

--- a/.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec.md
+++ b/.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec.md
@@ -1,0 +1,43 @@
+# Spec Requirements Document
+
+> Spec: Campaign Seed Character Copy
+> Created: 2025-08-25
+> Status: Planning
+
+## Overview
+
+Enhance the existing CampaignSeederService to copy all Character records from the Master Campaign when a new campaign is created. This provides new campaigns with established NPCs and example enemies to help gamemasters quickly populate their campaigns with ready-to-use characters.
+
+## User Stories
+
+### Automatic Character Population
+
+As a gamemaster creating a new campaign, I want to automatically receive a full set of example characters from the Master Campaign, so that I have immediate access to established NPCs and enemies without needing to create them from scratch.
+
+When I create a new campaign, the system automatically copies all Character records from the Master Campaign into my new campaign. These characters include various NPCs, bosses, featured foes, mooks, and allies that have been curated in the Master Campaign. I can immediately use these characters in my games, modify them as needed, or use them as templates for creating my own characters. This dramatically reduces the time needed to prepare for sessions and provides high-quality examples of well-designed characters.
+
+## Spec Scope
+
+1. **Character Copying** - Modify CampaignSeederService to copy all Character records from the Master Campaign to newly created campaigns
+2. **CharacterDuplicator Integration** - Utilize the existing CharacterDuplicator service to handle the character copying process
+3. **Automatic Execution** - Ensure character copying happens automatically during campaign creation without user intervention
+4. **Master Campaign Identification** - Implement logic to identify and access the Master Campaign for character sourcing
+
+## Out of Scope
+
+- User interface for selecting which characters to copy
+- Modification of copied character attributes during the copy process
+- Option to skip character copying
+- Changes to the CharacterDuplicator service itself
+- Copying of other entities (Fights, Sites, Parties, etc.)
+
+## Expected Deliverable
+
+1. When a new campaign is created, all Character records from the Master Campaign are automatically copied to the new campaign
+2. The copied characters are fully functional and editable within the new campaign
+3. The existing campaign creation flow remains unchanged from the user's perspective
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/2025-08-25-campaign-seed-character-copy/tasks.md
+- Technical Specification: @.agent-os/specs/2025-08-25-campaign-seed-character-copy/sub-specs/technical-spec.md

--- a/.agent-os/specs/2025-08-25-campaign-seed-character-copy/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-08-25-campaign-seed-character-copy/sub-specs/technical-spec.md
@@ -1,0 +1,38 @@
+# Technical Specification
+
+This is the technical specification for the spec detailed in @.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec.md
+
+> Created: 2025-08-25
+> Version: 1.0.0
+
+## Technical Requirements
+
+- **Modify CampaignSeederService** - Update the `call` method in `app/services/campaign_seeder_service.rb` to include character copying after existing seed operations
+- **Master Campaign Identification** - Implement method to identify the Master Campaign (likely by name or special flag)
+- **Batch Character Copying** - Use `CharacterDuplicator.new(character, campaign).call` for each Character record from the Master Campaign
+- **Error Handling** - Wrap character copying in appropriate error handling to prevent campaign creation failure if character copying encounters issues
+- **Logging** - Add Rails.logger statements to track character copying progress and any errors
+- **Transaction Safety** - Ensure character copying occurs within the same database transaction as campaign creation for data consistency
+- **Performance Optimization** - Consider using batch operations if the Master Campaign contains many characters to avoid N+1 queries
+
+## Approach
+
+### CampaignSeederService Modifications
+
+The service should:
+1. Identify the Master Campaign (e.g., `Campaign.find_by(name: "Master Campaign")`)
+2. After existing seed operations, iterate through `master_campaign.characters`
+3. For each character, call `CharacterDuplicator.new(character, @campaign).call`
+4. Handle any duplication errors gracefully without failing the entire campaign creation
+
+### Expected Code Location
+
+- Primary changes in: `shot-server/app/services/campaign_seeder_service.rb`
+- No frontend changes required as this is backend-only functionality
+- May need to update tests in: `shot-server/spec/services/campaign_seeder_service_spec.rb`
+
+## External Dependencies
+
+- **CharacterDuplicator** - Existing service class for duplicating characters between campaigns
+- **Campaign Model** - Master Campaign must exist and be identifiable
+- **Character Model** - Characters in Master Campaign must be properly structured for duplication

--- a/.agent-os/specs/2025-08-25-campaign-seed-character-copy/tasks.md
+++ b/.agent-os/specs/2025-08-25-campaign-seed-character-copy/tasks.md
@@ -1,0 +1,35 @@
+# Spec Tasks
+
+These are the tasks to be completed for the spec detailed in @.agent-os/specs/2025-08-25-campaign-seed-character-copy/spec.md
+
+> Created: 2025-08-25
+> Status: Ready for Implementation
+
+## Tasks
+
+- [ ] 1. Identify and Access Master Campaign
+  - [ ] 1.1 Write tests for Master Campaign identification logic
+  - [ ] 1.2 Implement method to find Master Campaign in CampaignSeederService
+  - [ ] 1.3 Add error handling for missing Master Campaign
+  - [ ] 1.4 Verify all tests pass
+
+- [ ] 2. Integrate Character Copying into Campaign Seeder
+  - [ ] 2.1 Write tests for character copying integration
+  - [ ] 2.2 Add character iteration logic after existing seed operations
+  - [ ] 2.3 Integrate CharacterDuplicator service calls
+  - [ ] 2.4 Add logging for character copy operations
+  - [ ] 2.5 Verify all tests pass
+
+- [ ] 3. Implement Error Handling and Transaction Safety
+  - [ ] 3.1 Write tests for error scenarios (failed duplication, missing characters)
+  - [ ] 3.2 Wrap character copying in rescue blocks
+  - [ ] 3.3 Ensure database transaction integrity
+  - [ ] 3.4 Add detailed error logging
+  - [ ] 3.5 Verify all tests pass
+
+- [ ] 4. End-to-End Testing
+  - [ ] 4.1 Write integration test for complete campaign creation with character copying
+  - [ ] 4.2 Test with various Master Campaign states (empty, many characters, special characters)
+  - [ ] 4.3 Verify character attributes are correctly preserved
+  - [ ] 4.4 Test campaign creation still works if Master Campaign is unavailable
+  - [ ] 4.5 Run full test suite to ensure no regressions

--- a/src/app/(main)/characters/create/page.tsx
+++ b/src/app/(main)/characters/create/page.tsx
@@ -20,24 +20,20 @@ export default async function CharacterCreatePage() {
 
   const response = await client.getCharacters({
     is_template: true,
+    character_type: "PC",
     sort: "name",
     order: "asc",
     per_page: 50,
   })
   const { characters } = response.data
   
-  console.log("Template characters fetched:", characters?.length || 0)
-
-  // Detect mobile device on the server
-  const headersState = await headers()
-  const userAgent = headersState.get("user-agent") || ""
-  const initialIsMobile = /mobile/i.test(userAgent)
+  console.log("PC Template characters fetched:", characters?.length || 0)
 
   return (
     <>
       <Breadcrumbs client={client} />
       <Suspense fallback={<CircularProgress />}>
-        <CreatePage templates={characters} initialIsMobile={initialIsMobile} />
+        <CreatePage templates={characters} />
       </Suspense>
     </>
   )

--- a/src/app/(main)/characters/gmc/page.tsx
+++ b/src/app/(main)/characters/gmc/page.tsx
@@ -1,0 +1,272 @@
+// app/characters/gmc-templates/page.tsx
+"use client"
+
+import { useState, useEffect } from "react"
+import { useRouter } from "next/navigation"
+import {
+  Box,
+  Container,
+  Typography,
+  Tabs,
+  Tab,
+  Grid,
+  Card,
+  CardContent,
+  CardActionArea,
+  Chip,
+  CircularProgress,
+  Alert,
+} from "@mui/material"
+import { useClient, useCampaign, useToast } from "@/contexts"
+import { MainHeader, Icon } from "@/components/ui"
+import { SpeedDial } from "@/components/characters"
+import type { Character } from "@/types"
+
+// GMC Types in Feng Shui 2
+const GMC_TYPES = [
+  { value: "Ally", label: "Ally", description: "Helpful NPCs" },
+  { value: "Mook", label: "Mook", description: "Standard enemies" },
+  { value: "Featured Foe", label: "Featured Foe", description: "Notable enemies" },
+  { value: "Boss", label: "Boss", description: "Major villains" },
+  { value: "Uber-Boss", label: "Uber-Boss", description: "Epic threats" },
+]
+
+interface TemplatePreviewCardProps {
+  template: Character
+  onSelect: (template: Character) => void
+}
+
+function TemplatePreviewCard({ template, onSelect }: TemplatePreviewCardProps) {
+  const actionValues = template.action_values || {}
+
+  // Extract key combat and defensive values
+  const primaryStats = [
+    { label: "Martial Arts", value: actionValues["Martial Arts"] },
+    { label: "Guns", value: actionValues["Guns"] },
+    { label: "Sorcery", value: actionValues["Sorcery"] },
+    { label: "Creature Powers", value: actionValues["Creature Powers"] },
+    { label: "Defense", value: actionValues["Defense"] },
+    { label: "Toughness", value: actionValues["Toughness"] },
+    { label: "Speed", value: actionValues["Speed"] },
+    { label: "Fortune", value: actionValues["Fortune"] },
+  ].filter(stat => stat.value && stat.value > 0)
+
+  return (
+    <Card sx={{ height: "100%" }}>
+      <CardActionArea onClick={() => onSelect(template)} sx={{ height: "100%" }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            {template.name}
+          </Typography>
+          <Chip
+            label={actionValues["Type"] || "GMC"}
+            color="primary"
+            size="small"
+            sx={{ mb: 2 }}
+          />
+
+          <Box sx={{ mt: 1 }}>
+            {primaryStats.map(stat => (
+              <Box
+                key={stat.label}
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  mb: 0.5,
+                }}
+              >
+                <Typography variant="body2" color="text.secondary">
+                  {stat.label}:
+                </Typography>
+                <Typography variant="body2" fontWeight="bold">
+                  {stat.value}
+                </Typography>
+              </Box>
+            ))}
+          </Box>
+
+          {template.description && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{ mt: 2, fontStyle: "italic" }}
+              noWrap
+            >
+              {template.description}
+            </Typography>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+export default function GMCTemplatesPage() {
+  const { client } = useClient()
+  const { campaign } = useCampaign()
+  const { toastSuccess, toastError } = useToast()
+  const router = useRouter()
+  const [selectedType, setSelectedType] = useState(0)
+  const [templatesByType, setTemplatesByType] = useState<Record<string, Character[]>>({})
+  const [loading, setLoading] = useState(true)
+  const [creatingFrom, setCreatingFrom] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadTemplates = async () => {
+      if (!campaign) return
+
+      setLoading(true)
+      try {
+        const templates: Record<string, Character[]> = {}
+
+        // Fetch templates for each GMC type
+        for (const gmcType of GMC_TYPES) {
+          const response = await client.getCharacters({
+            is_template: true,
+            character_type: gmcType.value,
+            per_page: 50,
+          })
+          templates[gmcType.value] = response.data.characters || []
+        }
+
+        setTemplatesByType(templates)
+      } catch (error) {
+        console.error("Error fetching templates:", error)
+        toastError("Failed to load GMC templates")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadTemplates()
+  }, [campaign, client, toastError])
+
+
+  const handleSelectTemplate = async (template: Character) => {
+    if (creatingFrom) return // Prevent double-clicking
+
+    setCreatingFrom(template.id)
+    try {
+      // Get full template data
+      const fullTemplate = await client.getCharacter(template.id)
+
+      // Create new character from template
+      const newCharacterData = {
+        ...fullTemplate.data,
+        id: undefined, // Remove ID so a new one is generated
+        is_template: false,
+        name: `${template.name} (Copy)`, // Add (Copy) suffix to differentiate
+      }
+
+      const response = await client.createCharacter({
+        character: newCharacterData,
+      })
+
+      toastSuccess(`Created new GMC from template: ${template.name}`)
+      router.push(`/characters/${response.data.id}`)
+    } catch (error) {
+      console.error("Error creating character from template:", error)
+      toastError("Failed to create GMC from template")
+    } finally {
+      setCreatingFrom(null)
+    }
+  }
+
+  const currentType = GMC_TYPES[selectedType]
+  const currentTemplates = templatesByType[currentType?.value] || []
+
+  return (
+    <Box
+      sx={{
+        justifyContent: "space-between",
+        alignItems: "center",
+        mb: 2,
+        position: "relative",
+      }}
+    >
+      <SpeedDial />
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          mb: 2,
+        }}
+      >
+        <MainHeader
+          title="Create GMC from Template"
+          icon={<Icon keyword="Characters" size="36" />}
+          subtitle="Select a Game Master Character template to quickly create NPCs"
+        />
+      </Box>
+
+      {loading ? (
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 4 }}>
+          <CircularProgress />
+        </Box>
+      ) : (
+        <>
+          <Box sx={{ borderBottom: 1, borderColor: "divider", mb: 3 }}>
+            <Tabs
+              value={selectedType}
+              onChange={(_, newValue) => setSelectedType(newValue)}
+              variant="scrollable"
+              scrollButtons="auto"
+            >
+              {GMC_TYPES.map((type) => (
+                <Tab
+                  key={type.value}
+                  label={
+                    <Box>
+                      <Typography variant="body1">{type.label}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {type.description}
+                      </Typography>
+                    </Box>
+                  }
+                />
+              ))}
+            </Tabs>
+          </Box>
+
+          {currentTemplates.length === 0 ? (
+            <Alert severity="info" sx={{ mt: 2 }}>
+              No {currentType?.label} templates available in this campaign. Templates
+              will be available after they are created in the Master Campaign.
+            </Alert>
+          ) : (
+            <Grid container spacing={3}>
+              {currentTemplates.map(template => (
+                <Grid item xs={12} sm={6} md={4} key={template.id}>
+                  <TemplatePreviewCard
+                    template={template}
+                    onSelect={handleSelectTemplate}
+                  />
+                </Grid>
+              ))}
+            </Grid>
+          )}
+
+          {creatingFrom && (
+            <Box
+              sx={{
+                position: "fixed",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                bgcolor: "rgba(0,0,0,0.5)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                zIndex: 9999,
+              }}
+            >
+              <CircularProgress />
+            </Box>
+          )}
+        </>
+      )}
+    </Box>
+  )
+}

--- a/src/app/(main)/characters/gmc/page.tsx
+++ b/src/app/(main)/characters/gmc/page.tsx
@@ -282,23 +282,12 @@ export default function GMCTemplatesPage() {
 
     setCreatingFrom(template.id)
     try {
-      // Get full template data
-      const fullTemplate = await client.getCharacter(template.id)
+      // Use the duplicate API to create a new character from the template
+      const response = await client.duplicateCharacter(template)
+      const newCharacter = response.data
 
-      // Create new character from template
-      const newCharacterData = {
-        ...fullTemplate.data,
-        id: undefined, // Remove ID so a new one is generated
-        is_template: false,
-        name: `${template.name} (Copy)`, // Add (Copy) suffix to differentiate
-      }
-
-      const response = await client.createCharacter({
-        character: newCharacterData,
-      })
-
-      toastSuccess(`Created new GMC from template: ${template.name}`)
-      router.push(`/characters/${response.data.id}`)
+      toastSuccess(`Created new GMC: ${newCharacter.name}`)
+      router.push(`/characters/${newCharacter.id}`)
     } catch (error) {
       console.error("Error creating character from template:", error)
       toastError("Failed to create GMC from template")

--- a/src/components/characters/CreatePage.test.tsx
+++ b/src/components/characters/CreatePage.test.tsx
@@ -1,0 +1,260 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import CreatePage from "./CreatePage"
+import { Character } from "@/types"
+
+// Mock the router
+const mockPush = jest.fn()
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}))
+
+// Mock the contexts
+const mockDuplicateCharacter = jest.fn()
+const mockRefreshUser = jest.fn()
+const mockToastSuccess = jest.fn()
+const mockToastError = jest.fn()
+
+jest.mock("@/contexts", () => ({
+  useClient: () => ({
+    client: {
+      duplicateCharacter: mockDuplicateCharacter,
+    },
+  }),
+  useApp: () => ({
+    refreshUser: mockRefreshUser,
+  }),
+  useToast: () => ({
+    toastSuccess: mockToastSuccess,
+    toastError: mockToastError,
+  }),
+}))
+
+// Mock UI components
+jest.mock("@/components/ui", () => ({
+  MainHeader: ({ title, subtitle }: any) => (
+    <div>
+      <h1>{title}</h1>
+      <p>{subtitle}</p>
+    </div>
+  ),
+  Icon: ({ keyword }: any) => <span>Icon: {keyword}</span>,
+}))
+
+// Mock character components
+jest.mock("@/components/characters/SpeedDial", () => ({
+  __esModule: true,
+  default: () => <div>SpeedDial</div>,
+}))
+
+jest.mock("@/components/characters/PCTemplatePreviewCard", () => ({
+  __esModule: true,
+  default: ({ template, onSelect, isLoading }: any) => (
+    <div 
+      onClick={() => !isLoading && onSelect(template)} 
+      role="article" 
+      aria-label={template.name}
+      style={{ opacity: isLoading ? 0.5 : 1 }}
+    >
+      <h3>{template.name}</h3>
+      <span>{template.archetype}</span>
+    </div>
+  ),
+}))
+
+describe("CreatePage", () => {
+  const mockTemplates: Character[] = [
+    {
+      id: "1",
+      name: "Archer",
+      archetype: "Archer",
+      skills: { "Archery": 3 },
+      schticks: [{ id: "s1", name: "Eagle Eye" }],
+      weapons: [{ id: "w1", name: "Bow", damage: 10, concealment: 0, reload: 0 }],
+    },
+    {
+      id: "2",
+      name: "Big Bruiser",
+      archetype: "Big Bruiser",
+      skills: { "Martial Arts": 3 },
+      schticks: [{ id: "s2", name: "Tough" }],
+      weapons: [],
+    },
+    {
+      id: "3",
+      name: "Cyborg",
+      archetype: "Cyborg",
+      skills: { "Guns": 3 },
+      schticks: [{ id: "s3", name: "Hardware" }],
+      weapons: [{ id: "w2", name: "Cyberlimb", damage: 12, concealment: 0, reload: 0 }],
+    },
+  ] as Character[]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("Layout and Display", () => {
+    it("displays the main header with correct title", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      expect(screen.getByText("Create Player Character")).toBeInTheDocument()
+      expect(screen.getByText("Choose an archetype to create your character")).toBeInTheDocument()
+    })
+
+    it("renders all template cards without carousel", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      // All templates should be visible
+      expect(screen.getByText("Archer")).toBeInTheDocument()
+      expect(screen.getByText("Big Bruiser")).toBeInTheDocument()
+      expect(screen.getByText("Cyborg")).toBeInTheDocument()
+      
+      // No carousel controls
+      expect(screen.queryByRole("button", { name: /next/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole("button", { name: /previous/i })).not.toBeInTheDocument()
+    })
+
+    it("displays result count", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      expect(screen.getByText(/Showing 3 of 3 templates/i)).toBeInTheDocument()
+    })
+
+    it("handles empty templates gracefully", () => {
+      render(<CreatePage templates={[]} />)
+      expect(screen.getByText(/No character templates available/i)).toBeInTheDocument()
+    })
+  })
+
+  describe("Search and Filter", () => {
+    it("shows search functionality", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      const searchInput = screen.getByPlaceholderText(/search templates/i)
+      expect(searchInput).toBeInTheDocument()
+    })
+
+    it("filters templates based on search input", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      const searchInput = screen.getByPlaceholderText(/search templates/i)
+      fireEvent.change(searchInput, { target: { value: "Archer" } })
+      
+      expect(screen.getByText("Archer")).toBeInTheDocument()
+      expect(screen.queryByText("Big Bruiser")).not.toBeInTheDocument()
+      expect(screen.queryByText("Cyborg")).not.toBeInTheDocument()
+    })
+
+    it("shows filter options", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      expect(screen.getByLabelText(/archetype/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/has weapons/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/has schticks/i)).toBeInTheDocument()
+    })
+
+    it("filters templates by has weapons", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      const hasWeaponsCheckbox = screen.getByLabelText(/has weapons/i)
+      fireEvent.click(hasWeaponsCheckbox)
+      
+      expect(screen.getByText("Archer")).toBeInTheDocument()
+      expect(screen.queryByText("Big Bruiser")).not.toBeInTheDocument()
+      expect(screen.getByText("Cyborg")).toBeInTheDocument()
+    })
+
+    it("clears all filters when clear button is clicked", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      // Apply a filter
+      const searchInput = screen.getByPlaceholderText(/search templates/i)
+      fireEvent.change(searchInput, { target: { value: "Archer" } })
+      
+      expect(screen.queryByText("Big Bruiser")).not.toBeInTheDocument()
+      
+      // Clear filters
+      const clearButton = screen.getByText(/clear filters/i)
+      fireEvent.click(clearButton)
+      
+      // All templates should be visible again
+      expect(screen.getByText("Archer")).toBeInTheDocument()
+      expect(screen.getByText("Big Bruiser")).toBeInTheDocument()
+      expect(screen.getByText("Cyborg")).toBeInTheDocument()
+    })
+
+    it("updates result count when filtering", () => {
+      render(<CreatePage templates={mockTemplates} />)
+      
+      const searchInput = screen.getByPlaceholderText(/search templates/i)
+      fireEvent.change(searchInput, { target: { value: "Archer" } })
+      
+      expect(screen.getByText(/Showing 1 of 3 templates/i)).toBeInTheDocument()
+    })
+  })
+
+  describe("Character Creation", () => {
+    it("creates character directly without confirmation dialog", async () => {
+      mockDuplicateCharacter.mockResolvedValue({
+        data: { id: "new-1", name: "New Archer" },
+      })
+      mockRefreshUser.mockResolvedValue(undefined)
+      
+      render(<CreatePage templates={mockTemplates} />)
+      
+      // Click on a template card
+      const archerCard = screen.getByRole("article", { name: "Archer" })
+      fireEvent.click(archerCard)
+      
+      // Should not show confirmation dialog
+      expect(screen.queryByText(/confirm character creation/i)).not.toBeInTheDocument()
+      
+      // Should call duplicate API directly
+      await waitFor(() => {
+        expect(mockDuplicateCharacter).toHaveBeenCalledWith(mockTemplates[0])
+      })
+      
+      // Should refresh user and redirect
+      await waitFor(() => {
+        expect(mockRefreshUser).toHaveBeenCalled()
+        expect(mockToastSuccess).toHaveBeenCalledWith("Created new character: New Archer")
+        expect(mockPush).toHaveBeenCalledWith("/characters/new-1")
+      })
+    })
+
+    it("shows loading overlay during character creation", async () => {
+      mockDuplicateCharacter.mockImplementation(
+        () => new Promise(resolve => setTimeout(() => resolve({
+          data: { id: "new-1", name: "New Archer" },
+        }), 100))
+      )
+      
+      render(<CreatePage templates={mockTemplates} />)
+      
+      // Click on a template card
+      const archerCard = screen.getByRole("article", { name: "Archer" })
+      fireEvent.click(archerCard)
+      
+      // Should show loading overlay
+      expect(screen.getByRole("progressbar")).toBeInTheDocument()
+      
+      // Wait for creation to complete
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalled()
+      })
+    })
+
+    it("handles creation error gracefully", async () => {
+      mockDuplicateCharacter.mockRejectedValue(new Error("Creation failed"))
+      
+      render(<CreatePage templates={mockTemplates} />)
+      
+      const archerCard = screen.getByRole("article", { name: "Archer" })
+      fireEvent.click(archerCard)
+      
+      await waitFor(() => {
+        expect(mockToastError).toHaveBeenCalledWith("Failed to create character from template")
+        expect(mockPush).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/components/characters/PCTemplatePreviewCard.test.tsx
+++ b/src/components/characters/PCTemplatePreviewCard.test.tsx
@@ -24,6 +24,7 @@ describe("PCTemplatePreviewCard", () => {
   const mockTemplate: Character = {
     id: "1",
     name: "Master Archer",
+    image_url: "https://example.com/archer.jpg",
     action_values: {
       "Martial Arts": 15,
       Defense: 14,
@@ -148,5 +149,21 @@ describe("PCTemplatePreviewCard", () => {
     render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
     
     expect(screen.getByText(/A skilled archer from ancient times/)).toBeInTheDocument()
+  })
+
+  it("displays character image when available", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    const image = screen.getByAltText("Master Archer")
+    expect(image).toBeInTheDocument()
+    expect(image).toHaveAttribute("src", "https://example.com/archer.jpg")
+  })
+
+  it("displays avatar with initials when no image available", () => {
+    const templateWithoutImage = { ...mockTemplate, image_url: undefined }
+    render(<PCTemplatePreviewCard template={templateWithoutImage} onSelect={mockOnSelect} />)
+    
+    // Should show avatar with initials "MA" for Master Archer
+    expect(screen.getByText("MA")).toBeInTheDocument()
   })
 })

--- a/src/components/characters/PCTemplatePreviewCard.test.tsx
+++ b/src/components/characters/PCTemplatePreviewCard.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+import PCTemplatePreviewCard from "./PCTemplatePreviewCard"
+import { Character } from "@/types"
+
+// Mock the CS service
+jest.mock("@/services", () => ({
+  CS: {
+    mainAttack: jest.fn((char) => "Martial Arts"),
+    mainAttackValue: jest.fn((char) => 15),
+    fortune: jest.fn((char) => 6),
+    fortuneType: jest.fn((char) => "Fortune"),
+    archetype: jest.fn((char) => "Archer"),
+    background: jest.fn((char) => "<p>A skilled archer from ancient times.</p>"),
+  }
+}))
+
+// Mock RichTextRenderer
+jest.mock("@/components/editor", () => ({
+  RichTextRenderer: ({ html }: { html: string }) => <div dangerouslySetInnerHTML={{ __html: html }} />
+}))
+
+describe("PCTemplatePreviewCard", () => {
+  const mockTemplate: Character = {
+    id: "1",
+    name: "Master Archer",
+    action_values: {
+      "Martial Arts": 15,
+      Defense: 14,
+      Toughness: 7,
+      Speed: 8,
+      Fortune: 6,
+      FortuneType: "Fortune"
+    },
+    skills: {
+      "Archery": 3,
+      "Stealth": 2,
+      "Tracking": 1
+    },
+    schticks: [
+      { id: "s1", name: "Both Guns Blazing" },
+      { id: "s2", name: "Eagle Eye" }
+    ],
+    weapons: [
+      { 
+        id: "w1", 
+        name: "Longbow",
+        damage: 10,
+        concealment: 0,
+        reload: 0
+      },
+      {
+        id: "w2",
+        name: "Dagger",
+        damage: 7,
+        concealment: 3,
+        reload: 0
+      }
+    ]
+  } as Character
+
+  const mockOnSelect = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("displays character name and archetype", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText("Master Archer")).toBeInTheDocument()
+    expect(screen.getByText("Archer")).toBeInTheDocument()
+  })
+
+  it("shows action values", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText("Martial Arts")).toBeInTheDocument()
+    expect(screen.getByText("15")).toBeInTheDocument()
+    expect(screen.getByText("Defense")).toBeInTheDocument()
+    expect(screen.getByText("14")).toBeInTheDocument()
+    expect(screen.getByText("Toughness")).toBeInTheDocument()
+    expect(screen.getByText("7")).toBeInTheDocument()
+    expect(screen.getByText("Speed")).toBeInTheDocument()
+    expect(screen.getByText("8")).toBeInTheDocument()
+  })
+
+  it("displays skills as chips", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText("Archery: 3")).toBeInTheDocument()
+    expect(screen.getByText("Stealth: 2")).toBeInTheDocument()
+    expect(screen.getByText("Tracking: 1")).toBeInTheDocument()
+  })
+
+  it("displays schticks as prominent chips", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText("Both Guns Blazing")).toBeInTheDocument()
+    expect(screen.getByText("Eagle Eye")).toBeInTheDocument()
+  })
+
+  it("displays weapons with stats", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText(/Longbow.*10\/0\/0/)).toBeInTheDocument()
+    expect(screen.getByText(/Dagger.*7\/3\/0/)).toBeInTheDocument()
+  })
+
+  it("calls onSelect when clicked", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    const card = screen.getByRole("button")
+    fireEvent.click(card)
+    
+    expect(mockOnSelect).toHaveBeenCalledWith(mockTemplate)
+  })
+
+  it("shows loading state when isLoading is true", () => {
+    const { container } = render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} isLoading={true} />)
+    
+    const card = container.querySelector(".MuiCard-root")
+    expect(card).toHaveStyle({ opacity: "0.5", pointerEvents: "none" })
+  })
+
+  it("handles templates without skills gracefully", () => {
+    const templateWithoutSkills = { ...mockTemplate, skills: undefined }
+    render(<PCTemplatePreviewCard template={templateWithoutSkills} onSelect={mockOnSelect} />)
+    
+    expect(screen.queryByText("Skills")).not.toBeInTheDocument()
+  })
+
+  it("handles templates without schticks gracefully", () => {
+    const templateWithoutSchticks = { ...mockTemplate, schticks: [] }
+    render(<PCTemplatePreviewCard template={templateWithoutSchticks} onSelect={mockOnSelect} />)
+    
+    expect(screen.queryByText("Schticks (Powers & Abilities)")).not.toBeInTheDocument()
+  })
+
+  it("handles templates without weapons gracefully", () => {
+    const templateWithoutWeapons = { ...mockTemplate, weapons: [] }
+    render(<PCTemplatePreviewCard template={templateWithoutWeapons} onSelect={mockOnSelect} />)
+    
+    expect(screen.queryByText("Weapons")).not.toBeInTheDocument()
+  })
+
+  it("displays background description", () => {
+    render(<PCTemplatePreviewCard template={mockTemplate} onSelect={mockOnSelect} />)
+    
+    expect(screen.getByText(/A skilled archer from ancient times/)).toBeInTheDocument()
+  })
+})

--- a/src/components/characters/PCTemplatePreviewCard.tsx
+++ b/src/components/characters/PCTemplatePreviewCard.tsx
@@ -4,10 +4,12 @@ import {
   Card,
   CardActionArea,
   CardContent,
+  CardMedia,
   Box,
   Typography,
   Grid,
-  Chip
+  Chip,
+  Avatar
 } from "@mui/material"
 import { RichTextRenderer } from "@/components/editor"
 import { CS } from "@/services"
@@ -51,6 +53,41 @@ export default function PCTemplatePreviewCard({
         sx={{ height: "100%", p: 0 }}
         disabled={isLoading}
       >
+        {/* Character Image */}
+        {template.image_url ? (
+          <CardMedia
+            component="img"
+            height="200"
+            image={template.image_url}
+            alt={template.name}
+            sx={{ 
+              objectFit: "cover",
+              bgcolor: "grey.100"
+            }}
+          />
+        ) : (
+          <Box 
+            sx={{ 
+              height: 200, 
+              display: "flex", 
+              alignItems: "center", 
+              justifyContent: "center",
+              bgcolor: "grey.100"
+            }}
+          >
+            <Avatar
+              sx={{ 
+                width: 80, 
+                height: 80,
+                fontSize: "2rem",
+                bgcolor: "primary.main"
+              }}
+            >
+              {template.name?.split(" ").map(word => word[0]).join("").substring(0, 2)}
+            </Avatar>
+          </Box>
+        )}
+        
         <CardContent sx={{ p: 2 }}>
           {/* Name and Archetype Section */}
           <Box sx={{ mb: 3 }}>

--- a/src/components/characters/PCTemplatePreviewCard.tsx
+++ b/src/components/characters/PCTemplatePreviewCard.tsx
@@ -1,0 +1,288 @@
+"use client"
+
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Box,
+  Typography,
+  Grid,
+  Chip
+} from "@mui/material"
+import { RichTextRenderer } from "@/components/editor"
+import { CS } from "@/services"
+import type { Character } from "@/types"
+
+interface PCTemplatePreviewCardProps {
+  template: Character
+  onSelect: (template: Character) => void
+  isLoading?: boolean
+}
+
+export default function PCTemplatePreviewCard({ 
+  template, 
+  onSelect,
+  isLoading = false 
+}: PCTemplatePreviewCardProps) {
+  const actionValues = template.action_values || {}
+  
+  // Get main attack info using CS service helpers
+  const mainAttackName = CS.mainAttack(template)
+  const mainAttackValue = CS.mainAttackValue(template)
+  const fortuneValue = CS.fortune(template)
+  const fortuneType = CS.fortuneType(template)
+  const archetype = CS.archetype(template)
+  const background = CS.background(template)
+
+  return (
+    <Card 
+      sx={{ 
+        height: "100%",
+        bgcolor: "background.paper",
+        border: "1px solid",
+        borderColor: "divider",
+        opacity: isLoading ? 0.5 : 1,
+        pointerEvents: isLoading ? "none" : "auto",
+        transition: "opacity 0.2s",
+      }}
+    >
+      <CardActionArea 
+        onClick={() => onSelect(template)} 
+        sx={{ height: "100%", p: 0 }}
+        disabled={isLoading}
+      >
+        <CardContent sx={{ p: 2 }}>
+          {/* Name and Archetype Section */}
+          <Box sx={{ mb: 3 }}>
+            <Typography variant="h5" sx={{ fontWeight: "bold" }}>
+              {template.name}
+            </Typography>
+            {archetype && (
+              <Typography variant="subtitle2" color="text.secondary">
+                {archetype}
+              </Typography>
+            )}
+          </Box>
+
+          {/* Action Values Section - Compact Display */}
+          <Box sx={{ mb: 2 }}>
+            <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: "bold" }}>
+              Action Values
+            </Typography>
+            
+            <Grid container spacing={1}>
+              {/* Main Attack */}
+              <Grid item xs={2}>
+                <Box sx={{ 
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1,
+                  textAlign: "center",
+                  bgcolor: "background.default",
+                  minHeight: "60px",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center"
+                }}>
+                  <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                    {mainAttackName}
+                  </Typography>
+                  <Typography variant="h6">
+                    {mainAttackValue}
+                  </Typography>
+                </Box>
+              </Grid>
+              
+              {/* Defense */}
+              <Grid item xs={2}>
+                <Box sx={{ 
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1,
+                  textAlign: "center",
+                  bgcolor: "background.default",
+                  minHeight: "60px",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center"
+                }}>
+                  <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                    Defense
+                  </Typography>
+                  <Typography variant="h6">
+                    {actionValues["Defense"] || 0}
+                  </Typography>
+                </Box>
+              </Grid>
+              
+              {/* Toughness */}
+              <Grid item xs={2}>
+                <Box sx={{ 
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1,
+                  textAlign: "center",
+                  bgcolor: "background.default",
+                  minHeight: "60px",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center"
+                }}>
+                  <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                    Toughness
+                  </Typography>
+                  <Typography variant="h6">
+                    {actionValues["Toughness"] || 0}
+                  </Typography>
+                </Box>
+              </Grid>
+
+              {/* Speed */}
+              <Grid item xs={2}>
+                <Box sx={{ 
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1,
+                  textAlign: "center",
+                  bgcolor: "background.default",
+                  minHeight: "60px",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center"
+                }}>
+                  <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                    Speed
+                  </Typography>
+                  <Typography variant="h6">
+                    {actionValues["Speed"] || 0}
+                  </Typography>
+                </Box>
+              </Grid>
+
+              {/* Fortune */}
+              <Grid item xs={2}>
+                <Box sx={{ 
+                  border: "1px solid",
+                  borderColor: "divider",
+                  borderRadius: 1,
+                  p: 1,
+                  textAlign: "center",
+                  bgcolor: "background.default",
+                  minHeight: "60px",
+                  display: "flex",
+                  flexDirection: "column",
+                  justifyContent: "center"
+                }}>
+                  <Typography variant="caption" sx={{ display: "block", mb: 0.5 }}>
+                    {fortuneType}
+                  </Typography>
+                  <Typography variant="h6">
+                    {fortuneValue}
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+          </Box>
+
+          {/* Skills Section */}
+          {template.skills && Object.keys(template.skills).length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: "bold" }}>
+                Skills
+              </Typography>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1 }}>
+                {Object.entries(template.skills)
+                  .filter(([_, value]) => value > 0)
+                  .map(([skill, value]) => (
+                    <Chip 
+                      key={skill}
+                      label={`${skill}: ${value}`}
+                      size="small"
+                      variant="filled"
+                      sx={{ 
+                        fontSize: "0.75rem",
+                        bgcolor: "action.selected",
+                      }}
+                    />
+                  ))}
+              </Box>
+            </Box>
+          )}
+
+          {/* Schticks Section - Critical for PC decision making */}
+          {template.schticks && template.schticks.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: "bold" }}>
+                Schticks (Powers & Abilities)
+              </Typography>
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+                {template.schticks.map(schtick => (
+                  <Chip 
+                    key={schtick.id}
+                    label={schtick.name}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    sx={{ fontSize: "0.75rem" }}
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+
+          {/* Weapons Section */}
+          {template.weapons && template.weapons.length > 0 && (
+            <Box sx={{ mb: 2 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1, fontWeight: "bold" }}>
+                Weapons
+              </Typography>
+              <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+                {template.weapons.slice(0, 3).map(weapon => (
+                  <Typography key={weapon.id} variant="caption" sx={{ 
+                    bgcolor: "background.default",
+                    p: 0.5,
+                    borderRadius: 1,
+                  }}>
+                    {weapon.name} ({weapon.damage || 0}/{weapon.concealment || 0}/{weapon.reload || 0})
+                  </Typography>
+                ))}
+                {template.weapons.length > 3 && (
+                  <Typography variant="caption" color="text.secondary">
+                    +{template.weapons.length - 3} more weapons
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+          )}
+
+          {/* Description - Brief excerpt */}
+          {background && (
+            <Box sx={{ 
+              mt: 2, 
+              pt: 2, 
+              borderTop: "1px solid", 
+              borderColor: "divider",
+              "& .tiptap": {
+                fontSize: "0.875rem",
+                lineHeight: 1.4,
+                color: "text.secondary",
+                "& p": { margin: 0 },
+                /* Truncate long descriptions */
+                display: "-webkit-box",
+                WebkitLineClamp: 3,
+                WebkitBoxOrient: "vertical",
+                overflow: "hidden",
+              }
+            }}>
+              <RichTextRenderer html={background} />
+            </Box>
+          )}
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  )
+}

--- a/src/components/characters/SpeedDial.tsx
+++ b/src/components/characters/SpeedDial.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation"
 import PersonAddAlt1Icon from "@mui/icons-material/PersonAddAlt1"
 import UploadIcon from "@mui/icons-material/Upload"
 import AddCircleOutlineIcon from "@mui/icons-material/AddCircleOutline"
+import GroupsIcon from "@mui/icons-material/Groups"
 import { SpeedDialMenu } from "@/components/ui"
 import { useState } from "react"
 
@@ -19,12 +20,17 @@ const handleImport = () => {
   redirect("/characters/import")
 }
 
+const handleGMCTemplates = () => {
+  redirect("/characters/gmc")
+}
+
 export const actions = [
-  { icon: <PersonAddAlt1Icon />, name: "Create", onClick: handleCreate },
-  { icon: <UploadIcon />, name: "Import", onClick: handleImport },
+  { icon: <PersonAddAlt1Icon />, name: "Create (PC)", onClick: handleCreate },
+  { icon: <GroupsIcon />, name: "Create (GMC)", onClick: handleGMCTemplates },
+  { icon: <UploadIcon />, name: "Import (from PDF)", onClick: handleImport },
   {
     icon: <AddCircleOutlineIcon />,
-    name: "Generate",
+    name: "Generate (by AI)",
     onClick: handleGenerate,
   },
 ]

--- a/src/components/characters/display/ActionValues.tsx
+++ b/src/components/characters/display/ActionValues.tsx
@@ -9,6 +9,8 @@ type ActionValuesProps = {
 }
 
 export default function ActionValues({ character, size }: ActionValuesProps) {
+  const isMook = CS.isMook(character)
+  
   return (
     <Box sx={{ display: "flex", justifyContent: "center" }}>
       <Stack
@@ -25,17 +27,21 @@ export default function ActionValues({ character, size }: ActionValuesProps) {
           value={CS.mainAttackValue(character)}
           size={size}
         />
-        <ActionValue
-          name={CS.secondaryAttack(character)}
-          value={CS.secondaryAttackValue(character)}
-          size={size}
-        />
+        {!isMook && (
+          <ActionValue
+            name={CS.secondaryAttack(character)}
+            value={CS.secondaryAttackValue(character)}
+            size={size}
+          />
+        )}
         <ActionValue name="Defense" value={CS.defense(character)} size={size} />
-        <ActionValue
-          name="Toughness"
-          value={CS.toughness(character)}
-          size={size}
-        />
+        {!isMook && (
+          <ActionValue
+            name="Toughness"
+            value={CS.toughness(character)}
+            size={size}
+          />
+        )}
         <ActionValue name="Speed" value={CS.speed(character)} size={size} />
         {CS.isPC(character) && (
           <ActionValue

--- a/src/components/characters/edit/ActionValuesEdit.tsx
+++ b/src/components/characters/edit/ActionValuesEdit.tsx
@@ -19,6 +19,8 @@ export default function ActionValuesEdit({
   setCharacter,
   updateCharacter,
 }: ActionValuesEditProps) {
+  const isMook = CS.isMook(character)
+  
   return (
     <Box sx={{ display: "flex", justifyContent: "center" }}>
       <Stack direction={{ xs: "column", md: "row" }} spacing={2} mb={2}>
@@ -32,15 +34,17 @@ export default function ActionValuesEdit({
             setCharacter={setCharacter}
             updateCharacter={updateCharacter}
           />
-          <AttackValueEdit
-            attack="SecondaryAttack"
-            name={CS.secondaryAttack(character)}
-            value={CS.secondaryAttackValue(character)}
-            size={size}
-            character={character}
-            setCharacter={setCharacter}
-            updateCharacter={updateCharacter}
-          />
+          {!isMook && (
+            <AttackValueEdit
+              attack="SecondaryAttack"
+              name={CS.secondaryAttack(character)}
+              value={CS.secondaryAttackValue(character)}
+              size={size}
+              character={character}
+              setCharacter={setCharacter}
+              updateCharacter={updateCharacter}
+            />
+          )}
           <ActionValue
             name="Defense"
             value={CS.defense(character)}
@@ -51,14 +55,16 @@ export default function ActionValuesEdit({
           />
         </Stack>
         <Stack direction="row" spacing={2}>
-          <ActionValue
-            name="Toughness"
-            value={CS.toughness(character)}
-            size={size}
-            character={character}
-            setCharacter={setCharacter}
-            updateCharacter={updateCharacter}
-          />
+          {!isMook && (
+            <ActionValue
+              name="Toughness"
+              value={CS.toughness(character)}
+              size={size}
+              character={character}
+              setCharacter={setCharacter}
+              updateCharacter={updateCharacter}
+            />
+          )}
           <ActionValue
             name="Speed"
             value={CS.speed(character)}

--- a/src/components/characters/edit/EditArchetype.tsx
+++ b/src/components/characters/edit/EditArchetype.tsx
@@ -36,10 +36,8 @@ export default function EditType({
   }
 
   const handleTypeChange = async (value: string | null) => {
-    if (!value) return
-
-    const updatedCharacter = CS.updateActionValue(character, "Archetype", value)
-    setArchetype(value)
+    const updatedCharacter = CS.updateActionValue(character, "Archetype", value || null)
+    setArchetype(value || null)
     updateCharacter(updatedCharacter)
   }
 
@@ -50,7 +48,7 @@ export default function EditType({
       value={archetype || ""}
       fetchOptions={fetchArchetypes}
       onChange={handleTypeChange}
-      allowNone={false}
+      allowNone={true}
     />
   )
 }

--- a/src/components/characters/edit/EditOwner.tsx
+++ b/src/components/characters/edit/EditOwner.tsx
@@ -37,13 +37,11 @@ export default function EditOwner({
   }
 
   const handleOwnerChange = async (newUserId: string | null) => {
-    if (!newUserId) return
-
     const updatedCharacter = {
       ...character,
-      user_id: newUserId,
+      user_id: newUserId || null,
     }
-    setOwnerId(newUserId)
+    setOwnerId(newUserId || "")
     updateCharacter(updatedCharacter)
   }
 
@@ -57,7 +55,7 @@ export default function EditOwner({
       value={ownerId}
       onChange={handleOwnerChange}
       filters={{ campaign_id: campaign?.id }}
-      allowNone={false}
+      allowNone={true}
     />
   )
 }

--- a/src/components/characters/edit/EditWealth.tsx
+++ b/src/components/characters/edit/EditWealth.tsx
@@ -31,13 +31,11 @@ export default function EditWealth({
   }
 
   const handleWealthChange = async (value: string | null) => {
-    if (!value) return
-
     const updatedCharacter = {
       ...character,
-      wealth: value,
+      wealth: value || null,
     }
-    setCharacterWealth(value)
+    setCharacterWealth(value || null)
     updateCharacter(updatedCharacter)
   }
 
@@ -47,7 +45,7 @@ export default function EditWealth({
       value={characterWealth || ""}
       fetchOptions={fetchCharacterWealths}
       onChange={handleWealthChange}
-      allowNone={false}
+      allowNone={true}
     />
   )
 }

--- a/src/components/characters/index.ts
+++ b/src/components/characters/index.ts
@@ -22,6 +22,7 @@ export { default as CharacterDescription } from "@/components/characters/Charact
 export { default as CharacterSpeedDial } from "@/components/characters/CharacterSpeedDial"
 export { default as SpeedDial } from "@/components/characters/SpeedDial"
 export { default as Template } from "@/components/characters/create/Template"
+export { default as PCTemplatePreviewCard } from "@/components/characters/PCTemplatePreviewCard"
 export { default as Show } from "@/components/characters/Show"
 export { default as ActionValuesEdit } from "@/components/characters/edit/ActionValuesEdit"
 export { default as ActionValueEdit } from "@/components/characters/edit/ActionValueEdit"

--- a/src/components/onboarding/OnboardingCarousel.tsx
+++ b/src/components/onboarding/OnboardingCarousel.tsx
@@ -21,7 +21,6 @@ import {
   Flag,
   Groups,
   LocationCity,
-  Close,
 } from "@mui/icons-material"
 import {
   OnboardingProgress,

--- a/src/contexts/__tests__/AppContext.authConflict.test.tsx
+++ b/src/contexts/__tests__/AppContext.authConflict.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { render, waitFor, screen } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 import { AppProvider } from "../AppContext"
 import Cookies from "js-cookie"
 import { Client } from "@/lib"


### PR DESCRIPTION
## Summary
- Replaced carousel-based template selection with modern, searchable card layout
- Added comprehensive filtering capabilities for better template discovery  
- Implemented direct character creation without confirmation dialogs

## Changes

### 1. PCTemplatePreviewCard Component
- New card component displaying template information in clean, scannable format
- Shows character image (or avatar fallback), name, archetype, action values
- Displays skills, schticks (powers), and weapons in organized sections
- Responsive design matching GMC interface patterns

### 2. Updated CreatePage Layout
- Removed dark carousel system entirely
- Implemented flexible card-based layout (not rigid grid)
- Added search bar with real-time filtering
- Added archetype dropdown filter
- Added checkboxes for "Has Weapons" and "Has Schticks"
- Shows result count (e.g., "Showing 12 of 36 templates")
- Direct click-to-create without confirmation dialog
- Loading overlay during character creation

### 3. Character Images
- Display character image_url prominently at top of each card
- Fallback to initials avatar when no image available
- Consistent 200px height for visual uniformity

### 4. API Integration
- Updated to fetch PC templates specifically using character_type: "PC" filter
- Maintains compatibility with existing duplicate character API

## Test Coverage
- Unit tests: 24 tests covering all component functionality
- E2E test: Comprehensive Playwright test validating entire user flow
- Test coverage includes search, filtering, creation, and error handling

## Breaking Changes
None - this is a complete replacement of the UI layer only

🤖 Generated with [Claude Code](https://claude.ai/code)