### PR TITLE
fix: Sync position state and improve upload feedback

### DIFF
--- a/src/components/generate/UploadImageDialog.tsx
+++ b/src/components/generate/UploadImageDialog.tsx
@@ -151,7 +151,7 @@ export function UploadImageDialog({
           name: "uploadStatus",
           value: "success",
         })
-        toastSuccess("Image uploaded successfully")
+        toastSuccess("Image uploaded successfully - positioning reset")
         handleConfirmClose()
       } catch (error) {
         console.error("Error uploading image:", error)

--- a/src/components/ui/PositionableImage.tsx
+++ b/src/components/ui/PositionableImage.tsx
@@ -57,6 +57,16 @@ export function PositionableImage({
     return () => window.removeEventListener("resize", updateBoxWidth)
   }, [])
 
+  // Reset position state when image URL changes (after upload)
+  useEffect(() => {
+    const newPosition = entity.image_positions?.find(
+      pos => pos.context === context
+    ) || { x_position: 0, y_position: 0 }
+    
+    setCurrentX(newPosition.x_position)
+    setCurrentY(newPosition.y_position)
+  }, [entity.image_url, entity.image_positions, context])
+
   const boxHeight = entity.image_url ? height : 100
 
   const handleDragStart = (


### PR DESCRIPTION
## Summary

- Fixes frontend state synchronization after image upload to work with backend position clearing
- Improves user feedback with informative toast message about position reset
- Ensures PositionableImage component reflects cleared positions without page refresh

## Technical Implementation

- **State Sync**: Added useEffect to PositionableImage component to sync position state when entity changes
- **User Feedback**: Updated upload success toast to mention "positioning reset" 
- **Reactive Updates**: Position state automatically resets to (0,0) when image_positions are cleared by backend

## Integration

- Works in conjunction with backend callback that clears image_position records on upload
- Provides seamless user experience: upload → automatic position reset → immediate repositioning capability
- Eliminates need for page refresh to reposition newly uploaded images

🤖 Generated with [Claude Code](https://claude.ai/code)