### PR TITLE
fix: Sync position state after image upload

### DIFF
--- a/src/components/ui/PositionableImage.tsx
+++ b/src/components/ui/PositionableImage.tsx
@@ -57,6 +57,16 @@ export function PositionableImage({
     return () => window.removeEventListener("resize", updateBoxWidth)
   }, [])
 
+  // Reset position state when image URL changes (after upload)
+  useEffect(() => {
+    const newPosition = entity.image_positions?.find(
+      pos => pos.context === context
+    ) || { x_position: 0, y_position: 0 }
+    
+    setCurrentX(newPosition.x_position)
+    setCurrentY(newPosition.y_position)
+  }, [entity.image_url, entity.image_positions, context])
+
   const boxHeight = entity.image_url ? height : 100
 
   const handleDragStart = (


### PR DESCRIPTION
## Summary

- Fixes frontend state synchronization after image upload to work with backend position clearing
- Ensures PositionableImage component reflects cleared positions without page refresh
- Provides seamless user experience for repositioning after upload

## Technical Implementation

- **State Sync**: Added useEffect to PositionableImage component to sync position state when entity changes
- **Reactive Updates**: Position state automatically resets to (0,0) when image_positions are cleared by backend
- **Integration**: Works in conjunction with backend callback that clears image_position records on upload

## User Experience

- Upload → automatic position reset → immediate repositioning capability
- No page refresh needed to reposition newly uploaded images
- Clean, simple success messaging without technical details

🤖 Generated with [Claude Code](https://claude.ai/code)