### PR TITLE
Fix avatar vertical centering in Table components

### DIFF
--- a/src/components/campaigns/Table.tsx
+++ b/src/components/campaigns/Table.tsx
@@ -95,7 +95,11 @@ export default function View({ formState, dispatchForm }: ViewProps) {
       width: 70,
       editable: false,
       sortable: false,
-      renderCell: params => <EntityAvatar entity={params.row} />,
+      renderCell: params => (
+        <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+          <EntityAvatar entity={params.row} />
+        </Box>
+      ),
       align: "center",
       headerAlign: "center",
     },

--- a/src/components/characters/Table.tsx
+++ b/src/components/characters/Table.tsx
@@ -12,6 +12,7 @@ import {
   FactionLink,
   CharacterLink,
 } from "@/components/ui"
+import { Box } from "@mui/material"
 import { CS } from "@/services"
 import { EntityAvatar } from "@/components/avatars"
 
@@ -27,7 +28,11 @@ const columns: GridColDef<Character>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",

--- a/src/components/factions/Table.tsx
+++ b/src/components/factions/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import { BaseDataGrid, FactionLink, MembersGroup } from "@/components/ui"
 import { EntityAvatar } from "@/components/avatars"
@@ -17,7 +18,11 @@ const columns: GridColDef<Faction>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",
@@ -34,7 +39,9 @@ const columns: GridColDef<Faction>[] = [
     editable: false,
     sortable: true,
     renderCell: params => (
-      <MembersGroup items={params.row.characters || []} max={3} />
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <MembersGroup items={params.row.characters || []} max={3} />
+      </Box>
     ),
   },
   {

--- a/src/components/fights/Table.tsx
+++ b/src/components/fights/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FightTableProps } from "@/types"
 import { MembersGroup, BaseDataGrid, FightLink } from "@/components/ui"
 import { EntityAvatar } from "@/components/avatars"
@@ -11,7 +12,11 @@ const columns: GridColDef<Fight>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",
@@ -42,11 +47,9 @@ const columns: GridColDef<Fight>[] = [
     editable: false,
     sortable: false,
     renderCell: params => (
-      <MembersGroup
-        items={params.row.characters || []}
-        max={3}
-        sx={{ mt: 1 }}
-      />
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <MembersGroup items={params.row.characters || []} max={3} />
+      </Box>
     ),
   },
   {

--- a/src/components/junctures/Table.tsx
+++ b/src/components/junctures/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import { BaseDataGrid, FactionLink, JunctureLink } from "@/components/ui"
 import { EntityAvatar } from "@/components/avatars"
@@ -17,7 +18,11 @@ const columns: GridColDef<Juncture>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",

--- a/src/components/parties/Table.tsx
+++ b/src/components/parties/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import {
   BaseDataGrid,
@@ -22,7 +23,11 @@ const columns: GridColDef<Party>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",
@@ -52,7 +57,9 @@ const columns: GridColDef<Party>[] = [
     editable: false,
     sortable: true,
     renderCell: params => (
-      <MembersGroup items={params.row.characters || []} max={3} />
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <MembersGroup items={params.row.characters || []} max={3} />
+      </Box>
     ),
   },
   {

--- a/src/components/schticks/Table.tsx
+++ b/src/components/schticks/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import { BaseDataGrid, SchtickLink } from "@/components/ui"
 import { EntityAvatar } from "@/components/avatars"
@@ -17,7 +18,11 @@ const columns: GridColDef<Schtick>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",

--- a/src/components/sites/Table.tsx
+++ b/src/components/sites/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import {
   BaseDataGrid,
@@ -22,7 +23,11 @@ const columns: GridColDef<Site>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} sx={{ mt: 0.5 }} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",
@@ -47,11 +52,9 @@ const columns: GridColDef<Site>[] = [
     editable: false,
     sortable: false,
     renderCell: params => (
-      <MembersGroup
-        items={params.row.characters || []}
-        max={3}
-        sx={{ mt: 1 }}
-      />
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <MembersGroup items={params.row.characters || []} max={3} />
+      </Box>
     ),
   },
   {

--- a/src/components/users/Table.tsx
+++ b/src/components/users/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { UserTableProps } from "@/types"
 import { BaseDataGrid, UserLink } from "@/components/ui"
 import { EntityAvatar } from "@/components/avatars"
@@ -11,7 +12,11 @@ const columns: GridColDef<User>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "email",

--- a/src/components/vehicles/Table.tsx
+++ b/src/components/vehicles/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import { FormStateType, FormStateAction } from "@/reducers"
 import { BaseDataGrid, FactionLink, VehicleLink } from "@/components/ui"
 import { VS } from "@/services"
@@ -18,7 +19,11 @@ const columns: GridColDef<Vehicle>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",

--- a/src/components/weapons/Table.tsx
+++ b/src/components/weapons/Table.tsx
@@ -1,5 +1,6 @@
 "use client"
 import { GridColDef } from "@mui/x-data-grid"
+import { Box } from "@mui/material"
 import {
   FormStateType,
   FormStateAction,
@@ -21,7 +22,11 @@ const columns: GridColDef<Weapon>[] = [
     width: 70,
     editable: false,
     sortable: false,
-    renderCell: params => <EntityAvatar entity={params.row} />,
+    renderCell: params => (
+      <Box sx={{ display: "flex", alignItems: "center", height: "100%" }}>
+        <EntityAvatar entity={params.row} />
+      </Box>
+    ),
   },
   {
     field: "name",


### PR DESCRIPTION
## Summary
- Fixed vertical alignment of avatars and avatar groups in all Table components
- Avatars were hitting the top edge of table rows, now properly centered

## Changes
- Wrapped all EntityAvatar components in Box with flex centering
- Wrapped all MembersGroup components in Box with flex centering  
- Applied consistent vertical centering across all entity tables

## Affected Components
### Individual Avatars (11 components):
- Characters Table
- Campaigns Table
- Fights Table
- Factions Table
- Junctures Table
- Parties Table
- Schticks Table
- Sites Table
- Users Table
- Vehicles Table
- Weapons Table

### Avatar Groups (4 components):
- Fights Table (Fighters column)
- Factions Table (Members column)
- Parties Table (Members column)
- Sites Table (Attuned column)

## Technical Details
All avatars and avatar groups are now wrapped in a Box component with:
- `display: "flex"`
- `alignItems: "center"`
- `height: "100%"`

This ensures proper vertical centering within DataGrid rows.

🤖 Generated with [Claude Code](https://claude.ai/code)