### PR TITLE
Fix campaign status display and filtering

### DIFF
--- a/src/components/campaigns/Table.tsx
+++ b/src/components/campaigns/Table.tsx
@@ -125,7 +125,8 @@ export default function View({ formState, dispatchForm }: ViewProps) {
       editable: false,
       sortable: false,
       renderCell: params => {
-        const isActive = params.row.id === currentCampaign?.id
+        const isCurrentCampaign = params.row.id === currentCampaign?.id
+        const isActive = params.row.active !== false // active can be true or null/undefined
         return (
           <Box
             sx={{
@@ -135,13 +136,15 @@ export default function View({ formState, dispatchForm }: ViewProps) {
               height: "100%",
             }}
           >
-            {isActive ? (
+            {isCurrentCampaign ? (
               <Chip
                 icon={<CheckCircle />}
-                label="Active"
+                label="Current"
                 color="success"
                 size="small"
               />
+            ) : isActive ? (
+              <Chip label="Active" color="primary" size="small" />
             ) : (
               <Chip label="Inactive" color="default" size="small" />
             )}


### PR DESCRIPTION
## Summary
- Fixed campaign status column to show the actual `active` field value from the database
- The status column now correctly shows:
  - 'Current' (green) for the currently selected campaign
  - 'Active' (blue) for campaigns with `active: true`
  - 'Inactive' (gray) for campaigns with `active: false`

## Problem
The visibility filter wasn't working correctly because the Status column was showing 'Active/Inactive' based on whether it was the currently selected campaign, not based on the campaign's actual `active` database field. This caused confusion where campaigns marked as 'Inactive' in the UI wouldn't appear when filtering by 'Inactive'.

## Solution
Updated the status column's render logic to check the campaign's actual `active` field value, while still showing 'Current' for the currently selected campaign to maintain that useful distinction.

## Testing
- Campaigns with `active: false` now correctly show as 'Inactive'
- Filtering by 'Inactive' now properly shows inactive campaigns
- The currently selected campaign shows as 'Current' regardless of its active status