### PR TITLE
Separate formatting check into its own CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
     working_directory: ~/repo
 
 jobs:
-  test:
+  format:
     executor: node-executor
     steps:
       - checkout
@@ -36,6 +36,28 @@ jobs:
       - run:
           name: Check formatting
           command: npm run format:check
+
+  test:
+    executor: node-executor
+    steps:
+      - checkout
+      
+      # Cache dependencies
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "package-lock.json" }}
+            - v2-dependencies-
+      
+      # Install dependencies
+      - run:
+          name: Install dependencies
+          command: npm ci
+      
+      # Save cache
+      - save_cache:
+          paths:
+            - node_modules
+          key: v2-dependencies-{{ checksum "package-lock.json" }}
       
       # Run linting
       - run:
@@ -129,10 +151,13 @@ workflows:
   version: 2
   test_build_deploy:
     jobs:
+      - format
+      
       - test
       
       - build:
           requires:
+            - format
             - test
       
       - deploy:


### PR DESCRIPTION
## Summary
- Separated formatting check from test job for better CI organization
- Format and test jobs now run in parallel for faster feedback
- Improves CI clarity and failure detection speed

## Changes
- Created new `format` job that only checks code formatting  
- Moved formatting check out of `test` job
- Updated workflow to run format and test in parallel
- Build job waits for both format and test to pass

## Benefits
- Faster CI feedback - formatting issues detected immediately
- Clearer CI output - separate status for formatting vs tests
- Better parallelization - format and test run simultaneously
- Easier debugging - formatting failures don't block test results