### PR TITLE
Fix inconsistent underline colors on auth pages

### DIFF
--- a/src/app/(auth)/forgot-password/ForgotPasswordClient.tsx
+++ b/src/app/(auth)/forgot-password/ForgotPasswordClient.tsx
@@ -90,6 +90,7 @@ export function ForgotPasswordClient() {
                 border: "none",
                 cursor: "pointer",
                 padding: 0,
+                font: "inherit",
               }}
               onClick={() => {
                 setSuccess(false)

--- a/src/app/(auth)/forgot-password/ForgotPasswordClient.tsx
+++ b/src/app/(auth)/forgot-password/ForgotPasswordClient.tsx
@@ -84,7 +84,8 @@ export function ForgotPasswordClient() {
               variant="body2"
               sx={{
                 color: "primary.main",
-                textDecoration: "underline",
+                textDecoration: "none",
+                "&:hover": { textDecoration: "underline" },
                 background: "none",
                 border: "none",
                 cursor: "pointer",

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -46,7 +46,14 @@ export default function ForgotPasswordPage() {
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
             Remember your password?{" "}
             <Link href="/login" passHref>
-              <MuiLink component="span" color="primary">
+              <MuiLink
+                component="span"
+                sx={{
+                  color: "primary.main",
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
                 Back to Login
               </MuiLink>
             </Link>

--- a/src/app/(auth)/forgot-password/page.tsx
+++ b/src/app/(auth)/forgot-password/page.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography, Container, Link as MuiLink } from "@mui/material"
+import { Box, Typography, Container } from "@mui/material"
 import Link from "next/link"
 import { ForgotPasswordClient } from "./ForgotPasswordClient"
 
@@ -45,8 +45,14 @@ export default function ForgotPasswordPage() {
         <Box sx={{ mt: 3, textAlign: "center" }}>
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
             Remember your password?{" "}
-            <Link href="/login" passHref>
-              <MuiLink
+            <Link
+              href="/login"
+              style={{
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              <Typography
                 component="span"
                 sx={{
                   color: "primary.main",
@@ -55,7 +61,7 @@ export default function ForgotPasswordPage() {
                 }}
               >
                 Back to Login
-              </MuiLink>
+              </Typography>
             </Link>
           </Typography>
         </Box>

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -223,8 +223,8 @@ export default function LoginPage() {
               <MuiLink
                 component="span"
                 variant="body2"
-                color="primary"
                 sx={{
+                  color: "primary.main",
                   textDecoration: "none",
                   "&:hover": { textDecoration: "underline" },
                 }}
@@ -276,8 +276,8 @@ export default function LoginPage() {
             <Link href="/register" passHref>
               <MuiLink
                 component="span"
-                color="primary"
                 sx={{
+                  color: "primary.main",
                   textDecoration: "none",
                   "&:hover": { textDecoration: "underline" },
                 }}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,13 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
-import {
-  Stack,
-  Box,
-  Typography,
-  Alert,
-  Container,
-} from "@mui/material"
+import { Stack, Box, Typography, Alert, Container } from "@mui/material"
 import Link from "next/link"
 import { Button, TextField } from "@/components/ui"
 import Cookies from "js-cookie"
@@ -231,7 +225,7 @@ export default function LoginPage() {
                 sx={{
                   color: "primary.main",
                   textDecoration: "none",
-                  "&:hover": { 
+                  "&:hover": {
                     textDecoration: "underline",
                   },
                 }}
@@ -292,7 +286,7 @@ export default function LoginPage() {
                 sx={{
                   color: "primary.main",
                   textDecoration: "none",
-                  "&:hover": { 
+                  "&:hover": {
                     textDecoration: "underline",
                   },
                 }}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -8,7 +8,6 @@ import {
   Typography,
   Alert,
   Container,
-  Link as MuiLink,
 } from "@mui/material"
 import Link from "next/link"
 import { Button, TextField } from "@/components/ui"
@@ -219,18 +218,26 @@ export default function LoginPage() {
             onChange={e => setPassword(e.target.value)}
           />
           <Box sx={{ textAlign: "right", mt: 1 }}>
-            <Link href="/forgot-password" passHref>
-              <MuiLink
-                component="span"
+            <Link
+              href="/forgot-password"
+              style={{
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              <Typography
                 variant="body2"
+                component="span"
                 sx={{
                   color: "primary.main",
                   textDecoration: "none",
-                  "&:hover": { textDecoration: "underline" },
+                  "&:hover": { 
+                    textDecoration: "underline",
+                  },
                 }}
               >
                 Forgot Password?
-              </MuiLink>
+              </Typography>
             </Link>
           </Box>
           <Button type="submit" sx={{ mt: 2, mb: 2 }}>
@@ -273,17 +280,25 @@ export default function LoginPage() {
         <Box sx={{ mt: 3, textAlign: "center" }}>
           <Typography variant="body2" sx={{ color: "#cccccc" }}>
             Don&rsquo;t have an account?{" "}
-            <Link href="/register" passHref>
-              <MuiLink
+            <Link
+              href="/register"
+              style={{
+                color: "inherit",
+                textDecoration: "none",
+              }}
+            >
+              <Typography
                 component="span"
                 sx={{
                   color: "primary.main",
                   textDecoration: "none",
-                  "&:hover": { textDecoration: "underline" },
+                  "&:hover": { 
+                    textDecoration: "underline",
+                  },
                 }}
               >
                 Create account
-              </MuiLink>
+              </Typography>
             </Link>
           </Typography>
         </Box>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -78,11 +78,11 @@ export default function RegisterPage() {
                 <Link href="/login" passHref>
                   <MuiLink
                     component="span"
-                    color="primary"
                     sx={{
+                      color: "primary.main",
                       textDecoration: "none",
                       "&:hover": { textDecoration: "underline" },
-                    }}
+                    }
                   >
                     Sign in
                   </MuiLink>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -2,12 +2,7 @@
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import {
-  Box,
-  Container,
-  Typography,
-  Alert,
-} from "@mui/material"
+import { Box, Container, Typography, Alert } from "@mui/material"
 import Link from "next/link"
 import { RegistrationForm } from "@/components/auth"
 

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Container,
   Typography,
-  Link as MuiLink,
   Alert,
 } from "@mui/material"
 import Link from "next/link"
@@ -75,17 +74,23 @@ export default function RegisterPage() {
             <Box sx={{ mt: 3, textAlign: "center" }}>
               <Typography variant="body2" sx={{ color: "#cccccc" }}>
                 Already have an account?{" "}
-                <Link href="/login" passHref>
-                  <MuiLink
+                <Link
+                  href="/login"
+                  style={{
+                    color: "inherit",
+                    textDecoration: "none",
+                  }}
+                >
+                  <Typography
                     component="span"
                     sx={{
                       color: "primary.main",
                       textDecoration: "none",
                       "&:hover": { textDecoration: "underline" },
-                    }
+                    }}
                   >
                     Sign in
-                  </MuiLink>
+                  </Typography>
                 </Link>
               </Typography>
             </Box>

--- a/src/app/(auth)/reset-password/[token]/page.tsx
+++ b/src/app/(auth)/reset-password/[token]/page.tsx
@@ -56,7 +56,14 @@ export default async function ResetPasswordPage({
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
             Need a new reset link?{" "}
             <Link href="/forgot-password" passHref>
-              <MuiLink component="span" color="primary">
+              <MuiLink
+                component="span"
+                sx={{
+                  color: "primary.main",
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
                 Request Password Reset
               </MuiLink>
             </Link>
@@ -67,7 +74,14 @@ export default async function ResetPasswordPage({
           <Typography variant="body2" sx={{ color: "text.secondary" }}>
             Remember your password?{" "}
             <Link href="/login" passHref>
-              <MuiLink component="span" color="primary">
+              <MuiLink
+                component="span"
+                sx={{
+                  color: "primary.main",
+                  textDecoration: "none",
+                  "&:hover": { textDecoration: "underline" },
+                }}
+              >
                 Back to Login
               </MuiLink>
             </Link>


### PR DESCRIPTION
## Summary
Fixes inconsistent link underline behavior and colors on authentication pages.

## Problems Fixed
1. **Underline inconsistency**: The forgot-password page had links with permanent underlines, while login and register pages only showed underlines on hover
2. **Color inconsistency**: 'Forgot Password?' link appeared gray/white instead of primary blue color
3. **Missing hover states**: Several auth page links were missing proper hover styling

## Solution  
- Updated all auth page links to match consistent pattern:
  - Use explicit `color: 'primary.main'` for proper blue color
  - No underline by default  
  - Underline appears on hover
- Ensures consistent visual behavior across all auth pages

## Files Changed
- `src/app/(auth)/login/page.tsx` - Fixed 'Forgot Password?' and 'Create account' links
- `src/app/(auth)/register/page.tsx` - Fixed 'Sign in' link
- `src/app/(auth)/forgot-password/page.tsx` - Fixed 'Back to Login' link
- `src/app/(auth)/forgot-password/ForgotPasswordClient.tsx` - Fixed resend email link
- `src/app/(auth)/reset-password/[token]/page.tsx` - Fixed both navigation links

## Testing
- Verified all auth page links now display in primary blue color
- All links have consistent no-underline default state
- Hover states work properly showing underline on all links
- Navigation flow between auth pages is visually consistent

## Screenshots
The 'Forgot Password?' link now appears in proper blue color instead of gray.