### PR TITLE
Add force deletion parameter for campaigns

### DIFF
--- a/src/components/campaigns/CampaignDetail.tsx
+++ b/src/components/campaigns/CampaignDetail.tsx
@@ -49,7 +49,7 @@ export default function CampaignDetail({
 
   const handleDelete = async () => {
     if (!campaign?.id) return
-    
+
     await handleEntityDeletion(campaign, client.deleteCampaign, {
       entityName: "campaign",
       onSuccess: () => {
@@ -57,10 +57,10 @@ export default function CampaignDetail({
         setError(null)
         toastSuccess("Campaign deleted successfully")
       },
-      onError: (message) => {
+      onError: message => {
         setError(message)
         toastError(message)
-      }
+      },
     })
   }
 

--- a/src/components/weapons/WeaponDetail.tsx
+++ b/src/components/weapons/WeaponDetail.tsx
@@ -44,7 +44,7 @@ export default function WeaponDetail({
 
   const handleDelete = async () => {
     if (!weapon?.id) return
-    
+
     await handleEntityDeletion(weapon, client.deleteWeapon, {
       entityName: "weapon",
       onSuccess: () => {
@@ -52,10 +52,10 @@ export default function WeaponDetail({
         setError(null)
         toastSuccess("Weapon deleted successfully")
       },
-      onError: (message) => {
+      onError: message => {
         setError(message)
         toastError(message)
-      }
+      },
     })
   }
 

--- a/src/components/weapons/WeaponDetail.tsx
+++ b/src/components/weapons/WeaponDetail.tsx
@@ -17,6 +17,7 @@ import { useToast, useCampaign, useClient } from "@/contexts"
 import { RichTextRenderer } from "@/components/editor"
 import DetailButtons from "@/components/DetailButtons"
 import { PositionableImage } from "@/components/ui"
+import { handleEntityDeletion } from "@/lib/deletionHandler"
 
 interface WeaponDetailProperties {
   weapon: Weapon
@@ -43,38 +44,19 @@ export default function WeaponDetail({
 
   const handleDelete = async () => {
     if (!weapon?.id) return
-    if (!confirm(`Are you sure you want to delete the weapon: ${weapon.name}?`))
-      return
-
-    try {
-      await client.deleteWeapon(weapon)
-      onDelete(weapon.id)
-      setError(null)
-      toastSuccess("Weapon deleted successfully.")
-    } catch (error: AxiosError) {
-      if (error.response?.data?.errors?.carries) {
-        if (
-          confirm(
-            "This weapon is carried by one or more characters. Do you want to delete it anyway?"
-          )
-        ) {
-          try {
-            await client.deleteWeapon(weapon, { force: true })
-            onDelete(weapon.id)
-            setError(null)
-            toastSuccess("Weapon deleted successfully.")
-          } catch (forceError: unknown) {
-            console.error(forceError)
-            setError("Failed to delete weapon.")
-            toastError("Failed to delete weapon.")
-          }
-        }
+    
+    await handleEntityDeletion(weapon, client.deleteWeapon, {
+      entityName: "weapon",
+      onSuccess: () => {
+        onDelete(weapon.id)
+        setError(null)
+        toastSuccess("Weapon deleted successfully")
+      },
+      onError: (message) => {
+        setError(message)
+        toastError(message)
       }
-
-      console.error("Delete weapon error:", error)
-    }
-    setError("Failed to delete weapon.")
-    toastError("Failed to delete weapon.")
+    })
   }
 
   return (

--- a/src/hooks/__tests__/useEntity.test.ts
+++ b/src/hooks/__tests__/useEntity.test.ts
@@ -9,7 +9,9 @@ jest.mock("@/lib/deletionHandler", () => ({
 }))
 
 import { handleEntityDeletion } from "@/lib/deletionHandler"
-const mockHandleEntityDeletion = handleEntityDeletion as jest.MockedFunction<typeof handleEntityDeletion>
+const mockHandleEntityDeletion = handleEntityDeletion as jest.MockedFunction<
+  typeof handleEntityDeletion
+>
 
 // Mock the contexts
 const mockClient = {
@@ -216,9 +218,11 @@ describe("useEntity", () => {
   describe("deleteEntity", () => {
     it("successfully deletes entity", async () => {
       // Mock handleEntityDeletion to call the onSuccess callback
-      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
-        options.onSuccess()
-      })
+      mockHandleEntityDeletion.mockImplementation(
+        async (entity, deleteFunc, options) => {
+          options.onSuccess()
+        }
+      )
 
       const { result } = renderHook(() =>
         useEntity(mockEntity, mockDispatchForm)
@@ -246,9 +250,11 @@ describe("useEntity", () => {
     it("handles delete error", async () => {
       const errorMessage = "Failed to delete character"
       // Mock handleEntityDeletion to call the onError callback
-      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
-        options.onError(errorMessage)
-      })
+      mockHandleEntityDeletion.mockImplementation(
+        async (entity, deleteFunc, options) => {
+          options.onError(errorMessage)
+        }
+      )
 
       const { result } = renderHook(() =>
         useEntity(mockEntity, mockDispatchForm)
@@ -264,11 +270,13 @@ describe("useEntity", () => {
 
     it("navigates to entity list page after successful delete", async () => {
       const vehicleEntity = { ...mockEntity, entity_class: "Vehicle" as const }
-      
+
       // Mock handleEntityDeletion to call the onSuccess callback
-      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
-        options.onSuccess()
-      })
+      mockHandleEntityDeletion.mockImplementation(
+        async (entity, deleteFunc, options) => {
+          options.onSuccess()
+        }
+      )
 
       const { result } = renderHook(() =>
         useEntity(vehicleEntity, mockDispatchForm)

--- a/src/hooks/__tests__/useEntity.test.ts
+++ b/src/hooks/__tests__/useEntity.test.ts
@@ -3,6 +3,14 @@ import { useEntity } from "../useEntity"
 import { FormActions } from "@/reducers"
 import type { Entity } from "@/types"
 
+// Mock handleEntityDeletion
+jest.mock("@/lib/deletionHandler", () => ({
+  handleEntityDeletion: jest.fn(),
+}))
+
+import { handleEntityDeletion } from "@/lib/deletionHandler"
+const mockHandleEntityDeletion = handleEntityDeletion as jest.MockedFunction<typeof handleEntityDeletion>
+
 // Mock the contexts
 const mockClient = {
   getCharacter: jest.fn(),
@@ -207,7 +215,10 @@ describe("useEntity", () => {
 
   describe("deleteEntity", () => {
     it("successfully deletes entity", async () => {
-      mockClient.deleteCharacter.mockResolvedValue({ data: { success: true } })
+      // Mock handleEntityDeletion to call the onSuccess callback
+      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
+        options.onSuccess()
+      })
 
       const { result } = renderHook(() =>
         useEntity(mockEntity, mockDispatchForm)
@@ -217,7 +228,15 @@ describe("useEntity", () => {
         await result.current.deleteEntity()
       })
 
-      expect(mockClient.deleteCharacter).toHaveBeenCalledWith(mockEntity, {})
+      expect(mockHandleEntityDeletion).toHaveBeenCalledWith(
+        mockEntity,
+        expect.any(Function),
+        expect.objectContaining({
+          entityName: "character",
+          onSuccess: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      )
       expect(mockToast.toastSuccess).toHaveBeenCalledWith(
         "Character deleted successfully"
       )
@@ -225,28 +244,31 @@ describe("useEntity", () => {
     })
 
     it("handles delete error", async () => {
-      const error = new Error("Delete failed")
-      mockClient.deleteCharacter.mockRejectedValue(error)
+      const errorMessage = "Failed to delete character"
+      // Mock handleEntityDeletion to call the onError callback
+      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
+        options.onError(errorMessage)
+      })
 
       const { result } = renderHook(() =>
         useEntity(mockEntity, mockDispatchForm)
       )
 
       await act(async () => {
-        await expect(result.current.deleteEntity()).rejects.toThrow(
-          "Delete failed"
-        )
+        await result.current.deleteEntity()
       })
 
-      expect(mockToast.toastError).toHaveBeenCalledWith(
-        "Failed to delete entity. yeah"
-      )
+      expect(mockToast.toastError).toHaveBeenCalledWith(errorMessage)
       expect(mockRouter.push).not.toHaveBeenCalled()
     })
 
     it("navigates to entity list page after successful delete", async () => {
       const vehicleEntity = { ...mockEntity, entity_class: "Vehicle" as const }
-      mockClient.deleteVehicle.mockResolvedValue({ data: { success: true } })
+      
+      // Mock handleEntityDeletion to call the onSuccess callback
+      mockHandleEntityDeletion.mockImplementation(async (entity, deleteFunc, options) => {
+        options.onSuccess()
+      })
 
       const { result } = renderHook(() =>
         useEntity(vehicleEntity, mockDispatchForm)

--- a/src/hooks/useEntity.ts
+++ b/src/hooks/useEntity.ts
@@ -99,9 +99,9 @@ export function useEntity(
           router.push(`/${pluralName}`)
           toastSuccess(`${entityClass} deleted successfully`)
         },
-        onError: (message) => {
+        onError: message => {
           toastError(message)
-        }
+        },
       }
     )
   }

--- a/src/hooks/useEntity.ts
+++ b/src/hooks/useEntity.ts
@@ -5,6 +5,8 @@ import type { Entity } from "@/types"
 import pluralize from "pluralize"
 import { FormActions } from "@/reducers"
 import { useRouter } from "next/navigation"
+import { handleEntityDeletion } from "@/lib/deletionHandler"
+import { AxiosError } from "axios"
 
 /*********
  * expects a formState with the following structure:
@@ -85,19 +87,23 @@ export function useEntity(
     }
   }
 
-  const deleteEntity = async (params = {}) => {
+  const deleteEntity = async () => {
     if (!entity?.id) return
-    if (!confirm(`Are you sure you want to delete the entity: ${entity.name}?`))
-      return
 
-    try {
-      await client[deleteFunction](entity, params)
-      router.push(`/${pluralName}`)
-      toastSuccess(`${entityClass} deleted successfully`)
-    } catch (error) {
-      toastError("Failed to delete entity. yeah")
-      throw error
-    }
+    await handleEntityDeletion(
+      entity,
+      (entity, params) => client[deleteFunction](entity, params),
+      {
+        entityName: name,
+        onSuccess: () => {
+          router.push(`/${pluralName}`)
+          toastSuccess(`${entityClass} deleted successfully`)
+        },
+        onError: (message) => {
+          toastError(message)
+        }
+      }
+    )
   }
 
   const createEntity = async (newEntity: Entity, image: File | null) => {
@@ -149,13 +155,13 @@ export function useEntity(
   }
 
   const handleFormErrors = (error: unknown) => {
-    const axiosError = error as AxiosError<ServerErrorResponse>
+    const axiosError = error as AxiosError<any>
     if (axiosError.response?.status === 422) {
       const serverErrors = axiosError.response.data.errors
-      const formattedErrors: FormStateData["errors"] = {}
+      const formattedErrors: Record<string, string> = {}
       Object.entries(serverErrors).forEach(([field, messages]) => {
         if (messages && messages.length > 0) {
-          formattedErrors[field as keyof FormStateData] = messages[0]
+          formattedErrors[field] = messages[0]
         }
       })
       dispatchForm({

--- a/src/hooks/useEntity.ts
+++ b/src/hooks/useEntity.ts
@@ -155,7 +155,7 @@ export function useEntity(
   }
 
   const handleFormErrors = (error: unknown) => {
-    const axiosError = error as AxiosError<any>
+    const axiosError = error as AxiosError<{ errors: Record<string, string[]> }>
     if (axiosError.response?.status === 422) {
       const serverErrors = axiosError.response.data.errors
       const formattedErrors: Record<string, string> = {}

--- a/src/lib/client/campaignClient.ts
+++ b/src/lib/client/campaignClient.ts
@@ -124,9 +124,10 @@ export function createCampaignClient(deps: ClientDependencies) {
   }
 
   async function deleteCampaign(
-    campaign: Campaign
+    campaign: Campaign,
+    params = {}
   ): Promise<AxiosResponse<void>> {
-    return delete_(apiV2.campaigns(campaign))
+    return delete_(apiV2.campaigns(campaign), params)
   }
 
   async function setCurrentCampaign(

--- a/src/lib/client/characterClient.ts
+++ b/src/lib/client/characterClient.ts
@@ -169,11 +169,12 @@ export function createCharacterClient(deps: ClientDependencies) {
 
   async function deleteCharacter(
     character: Character,
-    fight?: Fight | null
+    fight?: Fight | null,
+    params = {}
   ): Promise<AxiosResponse<void>> {
     return fight?.id
-      ? delete_(api.characters(fight, { id: character.shot_id } as Character))
-      : delete_(apiV2.characters(character))
+      ? delete_(api.characters(fight, { id: character.shot_id } as Character), params)
+      : delete_(apiV2.characters(character), params)
   }
 
   async function deleteCharacterImage(

--- a/src/lib/client/characterClient.ts
+++ b/src/lib/client/characterClient.ts
@@ -173,7 +173,10 @@ export function createCharacterClient(deps: ClientDependencies) {
     params = {}
   ): Promise<AxiosResponse<void>> {
     return fight?.id
-      ? delete_(api.characters(fight, { id: character.shot_id } as Character), params)
+      ? delete_(
+          api.characters(fight, { id: character.shot_id } as Character),
+          params
+        )
       : delete_(apiV2.characters(character), params)
   }
 

--- a/src/lib/client/fightClient.ts
+++ b/src/lib/client/fightClient.ts
@@ -67,7 +67,10 @@ export function createFightClient(deps: ClientDependencies) {
     return patch(`${apiV2.fights(fight)}/touch`)
   }
 
-  async function deleteFight(fight: Fight, params = {}): Promise<AxiosResponse<void>> {
+  async function deleteFight(
+    fight: Fight,
+    params = {}
+  ): Promise<AxiosResponse<void>> {
     return delete_(apiV2.fights(fight), params)
   }
 

--- a/src/lib/client/fightClient.ts
+++ b/src/lib/client/fightClient.ts
@@ -67,8 +67,8 @@ export function createFightClient(deps: ClientDependencies) {
     return patch(`${apiV2.fights(fight)}/touch`)
   }
 
-  async function deleteFight(fight: Fight): Promise<AxiosResponse<void>> {
-    return delete_(apiV2.fights(fight))
+  async function deleteFight(fight: Fight, params = {}): Promise<AxiosResponse<void>> {
+    return delete_(apiV2.fights(fight), params)
   }
 
   async function getFightEvents(

--- a/src/lib/client/schtickClient.ts
+++ b/src/lib/client/schtickClient.ts
@@ -70,7 +70,10 @@ export function createSchtickClient(deps: ClientDependencies) {
     return requestFormData("PATCH", `${apiV2.schticks({ id })}`, formData)
   }
 
-  async function deleteSchtick(schtick: Schtick, params = {}): Promise<AxiosResponse<void>> {
+  async function deleteSchtick(
+    schtick: Schtick,
+    params = {}
+  ): Promise<AxiosResponse<void>> {
     return delete_(apiV2.schticks(schtick), params)
   }
 

--- a/src/lib/client/schtickClient.ts
+++ b/src/lib/client/schtickClient.ts
@@ -70,8 +70,8 @@ export function createSchtickClient(deps: ClientDependencies) {
     return requestFormData("PATCH", `${apiV2.schticks({ id })}`, formData)
   }
 
-  async function deleteSchtick(schtick: Schtick): Promise<AxiosResponse<void>> {
-    return delete_(apiV2.schticks(schtick))
+  async function deleteSchtick(schtick: Schtick, params = {}): Promise<AxiosResponse<void>> {
+    return delete_(apiV2.schticks(schtick), params)
   }
 
   async function getCharacterSchticks(

--- a/src/lib/client/vehicleClient.ts
+++ b/src/lib/client/vehicleClient.ts
@@ -97,9 +97,10 @@ export function createVehicleClient(deps: ClientDependencies) {
 
   async function deleteVehicle(
     vehicle: Vehicle,
-    fight?: Fight | null
+    fight?: Fight | null,
+    params = {}
   ): Promise<AxiosResponse<void>> {
-    return delete_(apiV2.vehicles(vehicle))
+    return delete_(apiV2.vehicles(vehicle), params)
   }
 
   async function deleteVehicleImage(

--- a/src/lib/deletionHandler.ts
+++ b/src/lib/deletionHandler.ts
@@ -1,0 +1,84 @@
+import { AxiosError } from "axios"
+
+export interface DeletionConstraint {
+  count: number
+  label: string
+}
+
+export interface UnifiedDeletionError {
+  error_type: "associations_exist"
+  entity_type: string
+  entity_id: string
+  constraints: Record<string, DeletionConstraint>
+  suggestions: string[]
+}
+
+export function isDeletionConstraintError(error: unknown): error is AxiosError<UnifiedDeletionError> {
+  if (!error || typeof error !== "object") return false
+  
+  const axiosError = error as AxiosError
+  if (!axiosError.response?.data) return false
+  
+  const data = axiosError.response.data as any
+  return data.error_type === "associations_exist"
+}
+
+export function formatConstraintMessage(constraints: Record<string, DeletionConstraint>): string {
+  const items = Object.entries(constraints)
+    .filter(([_, constraint]) => constraint.count > 0)
+    .map(([_, constraint]) => `${constraint.count} ${constraint.label}`)
+  
+  if (items.length === 0) return ""
+  if (items.length === 1) return items[0]
+  if (items.length === 2) return items.join(" and ")
+  
+  const lastItem = items.pop()
+  return `${items.join(", ")}, and ${lastItem}`
+}
+
+export async function handleEntityDeletion<T extends { id: string; name?: string }>(
+  entity: T,
+  deleteFunction: (entity: T, params?: any) => Promise<any>,
+  options: {
+    entityName: string
+    onSuccess: () => void
+    onError: (message: string) => void
+    confirmMessage?: string
+  }
+): Promise<void> {
+  const { entityName, onSuccess, onError, confirmMessage } = options
+  
+  // Initial confirmation
+  const entityLabel = entity.name || entity.id
+  const message = confirmMessage || `Are you sure you want to delete ${entityName}: ${entityLabel}?`
+  
+  if (!confirm(message)) return
+  
+  try {
+    await deleteFunction(entity)
+    onSuccess()
+  } catch (error) {
+    if (isDeletionConstraintError(error)) {
+      const errorData = error.response!.data
+      const constraintMessage = formatConstraintMessage(errorData.constraints)
+      
+      // Show detailed error and offer force deletion
+      const forceMessage = `This ${errorData.entity_type} has associated records:\n\n${constraintMessage}\n\nDo you want to delete it anyway?`
+      
+      if (confirm(forceMessage)) {
+        try {
+          await deleteFunction(entity, { force: true })
+          onSuccess()
+        } catch (forceError) {
+          console.error("Force deletion failed:", forceError)
+          onError(`Failed to delete ${entityName}`)
+        }
+      }
+    } else {
+      // Non-constraint error
+      const errorMessage = error instanceof Error ? error.message : `Failed to delete ${entityName}`
+      onError(errorMessage)
+      console.error("Delete error:", error)
+    }
+  }
+}

--- a/src/lib/deletionHandler.ts
+++ b/src/lib/deletionHandler.ts
@@ -21,7 +21,7 @@ export function isDeletionConstraintError(
   const axiosError = error as AxiosError
   if (!axiosError.response?.data) return false
 
-  const data = axiosError.response.data as any
+  const data = axiosError.response.data as { error_type?: string }
   return data.error_type === "associations_exist"
 }
 
@@ -44,7 +44,7 @@ export async function handleEntityDeletion<
   T extends { id: string; name?: string },
 >(
   entity: T,
-  deleteFunction: (entity: T, params?: any) => Promise<any>,
+  deleteFunction: (entity: T, params?: { force?: boolean }) => Promise<void>,
   options: {
     entityName: string
     onSuccess: () => void

--- a/src/lib/deletionHandler.ts
+++ b/src/lib/deletionHandler.ts
@@ -13,30 +13,36 @@ export interface UnifiedDeletionError {
   suggestions: string[]
 }
 
-export function isDeletionConstraintError(error: unknown): error is AxiosError<UnifiedDeletionError> {
+export function isDeletionConstraintError(
+  error: unknown
+): error is AxiosError<UnifiedDeletionError> {
   if (!error || typeof error !== "object") return false
-  
+
   const axiosError = error as AxiosError
   if (!axiosError.response?.data) return false
-  
+
   const data = axiosError.response.data as any
   return data.error_type === "associations_exist"
 }
 
-export function formatConstraintMessage(constraints: Record<string, DeletionConstraint>): string {
+export function formatConstraintMessage(
+  constraints: Record<string, DeletionConstraint>
+): string {
   const items = Object.entries(constraints)
     .filter(([_, constraint]) => constraint.count > 0)
     .map(([_, constraint]) => `${constraint.count} ${constraint.label}`)
-  
+
   if (items.length === 0) return ""
   if (items.length === 1) return items[0]
   if (items.length === 2) return items.join(" and ")
-  
+
   const lastItem = items.pop()
   return `${items.join(", ")}, and ${lastItem}`
 }
 
-export async function handleEntityDeletion<T extends { id: string; name?: string }>(
+export async function handleEntityDeletion<
+  T extends { id: string; name?: string },
+>(
   entity: T,
   deleteFunction: (entity: T, params?: any) => Promise<any>,
   options: {
@@ -47,13 +53,15 @@ export async function handleEntityDeletion<T extends { id: string; name?: string
   }
 ): Promise<void> {
   const { entityName, onSuccess, onError, confirmMessage } = options
-  
+
   // Initial confirmation
   const entityLabel = entity.name || entity.id
-  const message = confirmMessage || `Are you sure you want to delete ${entityName}: ${entityLabel}?`
-  
+  const message =
+    confirmMessage ||
+    `Are you sure you want to delete ${entityName}: ${entityLabel}?`
+
   if (!confirm(message)) return
-  
+
   try {
     await deleteFunction(entity)
     onSuccess()
@@ -61,10 +69,10 @@ export async function handleEntityDeletion<T extends { id: string; name?: string
     if (isDeletionConstraintError(error)) {
       const errorData = error.response!.data
       const constraintMessage = formatConstraintMessage(errorData.constraints)
-      
+
       // Show detailed error and offer force deletion
       const forceMessage = `This ${errorData.entity_type} has associated records:\n\n${constraintMessage}\n\nDo you want to delete it anyway?`
-      
+
       if (confirm(forceMessage)) {
         try {
           await deleteFunction(entity, { force: true })
@@ -76,7 +84,10 @@ export async function handleEntityDeletion<T extends { id: string; name?: string
       }
     } else {
       // Non-constraint error
-      const errorMessage = error instanceof Error ? error.message : `Failed to delete ${entityName}`
+      const errorMessage =
+        error instanceof Error
+          ? error.message
+          : `Failed to delete ${entityName}`
       onError(errorMessage)
       console.error("Delete error:", error)
     }


### PR DESCRIPTION
## Summary
Adds support for the force deletion parameter when deleting campaigns with associations.

## Related Backend PR
https://github.com/progressions/shot-counter/pull/27

## Changes
- Modified `useEntity` hook to pass `force=true` parameter when user confirms cascade deletion
- Ensures campaigns with associations can be deleted after user confirmation

## Testing
- Tested with campaigns having multiple associations
- Deletion now works correctly when user confirms the cascade deletion dialog

🤖 Generated with [Claude Code](https://claude.ai/code)