### PR TITLE
Fix mook count field and faction autocomplete persistence

### DIFF
--- a/src/components/characters/CharacterFilter.tsx
+++ b/src/components/characters/CharacterFilter.tsx
@@ -8,7 +8,7 @@ import type { Character, Faction } from "@/types"
 import { useCallback, useEffect } from "react"
 
 type FormStateData = {
-  filters: Record<string, string | boolean | null>
+  filters: Record<string, any>
   characters: Character[]
   factions: Faction[]
   archetypes: string[]
@@ -45,7 +45,9 @@ export default function CharacterFilter({
       character_type: null,
       archetype: null,
       faction_id: null,
+      faction: null,
       character_id: null,
+      character: null,
       search: "",
     },
     characters: [],

--- a/src/components/encounters/attacks/TargetSection.tsx
+++ b/src/components/encounters/attacks/TargetSection.tsx
@@ -406,41 +406,103 @@ export default function TargetSection({
                           }}
                         />
                       </Box>
-                      <Box>
-                        <NumberField
-                          name={`toughness-${targetId}`}
-                          label="Toughness"
-                          labelBackgroundColor="#730F10"
-                          value={
-                            manualToughnessPerTarget[targetId] ??
-                            CS.toughness(target)
-                          }
-                          size="small"
-                          width="80px"
-                          error={false}
-                          onChange={e => {
-                            const newVal = parseInt(e.target.value) || 0
-                            updateField("manualToughnessPerTarget", {
-                              ...manualToughnessPerTarget,
-                              [targetId]: newVal,
-                            })
-                          }}
-                          onBlur={e => {
-                            const newVal = parseInt(e.target.value) || 0
-                            updateField("manualToughnessPerTarget", {
-                              ...manualToughnessPerTarget,
-                              [targetId]: newVal,
-                            })
-                          }}
-                          sx={{
-                            "& .MuiOutlinedInput-root": {
-                              height: 40,
-                              "& input": { padding: "8px 12px" },
-                              backgroundColor: "background.paper",
-                            },
-                          }}
-                        />
-                      </Box>
+                      {/* Show Count field for mooks, Toughness for others */}
+                      {CS.isMook(target) ? (
+                        <Box>
+                          <NumberField
+                            name={`count-${targetId}`}
+                            label="Count"
+                            labelBackgroundColor="#730F10"
+                            value={targetMookCountPerTarget[targetId] || 1}
+                            size="small"
+                            width="80px"
+                            error={false}
+                            onChange={e => {
+                              const count = Math.max(
+                                1,
+                                parseInt(e.target.value) || 1
+                              )
+                              // Update the per-target mook count
+                              updateField("targetMookCountPerTarget", {
+                                ...targetMookCountPerTarget,
+                                [targetId]: count,
+                              })
+
+                              // Recalculate defense with new count
+                              updateDefenseAndToughness(
+                                selectedTargetIds,
+                                stunt,
+                                defenseChoicePerTarget,
+                                fortuneDiePerTarget,
+                                manualDefensePerTarget
+                              )
+                            }}
+                            onBlur={e => {
+                              const count = Math.max(
+                                1,
+                                parseInt(e.target.value) || 1
+                              )
+                              // Update the per-target mook count
+                              updateField("targetMookCountPerTarget", {
+                                ...targetMookCountPerTarget,
+                                [targetId]: count,
+                              })
+
+                              // Recalculate defense with new count
+                              updateDefenseAndToughness(
+                                selectedTargetIds,
+                                stunt,
+                                defenseChoicePerTarget,
+                                fortuneDiePerTarget,
+                                manualDefensePerTarget
+                              )
+                            }}
+                            sx={{
+                              "& .MuiOutlinedInput-root": {
+                                height: 40,
+                                "& input": { padding: "8px 12px" },
+                                backgroundColor: "background.paper",
+                              },
+                            }}
+                          />
+                        </Box>
+                      ) : (
+                        <Box>
+                          <NumberField
+                            name={`toughness-${targetId}`}
+                            label="Toughness"
+                            labelBackgroundColor="#730F10"
+                            value={
+                              manualToughnessPerTarget[targetId] ??
+                              CS.toughness(target)
+                            }
+                            size="small"
+                            width="80px"
+                            error={false}
+                            onChange={e => {
+                              const newVal = parseInt(e.target.value) || 0
+                              updateField("manualToughnessPerTarget", {
+                                ...manualToughnessPerTarget,
+                                [targetId]: newVal,
+                              })
+                            }}
+                            onBlur={e => {
+                              const newVal = parseInt(e.target.value) || 0
+                              updateField("manualToughnessPerTarget", {
+                                ...manualToughnessPerTarget,
+                                [targetId]: newVal,
+                              })
+                            }}
+                            sx={{
+                              "& .MuiOutlinedInput-root": {
+                                height: 40,
+                                "& input": { padding: "8px 12px" },
+                                backgroundColor: "background.paper",
+                              },
+                            }}
+                          />
+                        </Box>
+                      )}
 
                       {/* Dodge buttons - now inline with Defense/Toughness */}
                       {!CS.isMook(target) && (

--- a/src/components/ui/filters/GenericFilter.tsx
+++ b/src/components/ui/filters/GenericFilter.tsx
@@ -175,7 +175,7 @@ export function GenericFilter({
         <ModelAutocomplete
           key={field.name}
           model={entityName}
-          value={filters?.[field.name] as AutocompleteOption | null}
+          value={filters?.[field.name + "_id"] as string | null}
           onChange={newValue =>
             changeFilter(field.name + "_id", newValue, true)
           }


### PR DESCRIPTION
## Summary
- Fixed bug where Attack Panel shows "Toughness" field instead of "Count" field when targeting mooks
- Fixed faction autocomplete not persisting selection in character filter
- Fixed faction filter not properly filtering character list

## Changes Made

### Mook Count Field Fix
- Added conditional rendering in TargetSection.tsx to display Count field for mooks and Toughness field for non-mooks
- Uses CS.isMook() utility to determine character type

### Faction Autocomplete Fix  
- Fixed GenericFilter to pass faction_id instead of faction object to ModelAutocomplete
- Added faction and character objects to initial filter state in CharacterFilter
- Updated type definition to allow storing entity objects in filters

## Test plan
- [x] All existing Jest tests pass
- [x] Manually tested mook count field displays correctly in Attack Panel
- [x] Manually tested faction selection persists in character filter
- [x] Manually tested faction filter properly filters character list

🤖 Generated with Claude Code