### PR TITLE
Fix duplicate API requests on GMC template page

### DIFF
--- a/src/app/(main)/characters/gmc/page.tsx
+++ b/src/app/(main)/characters/gmc/page.tsx
@@ -303,7 +303,7 @@ export default function GMCTemplatesPage() {
 
   useEffect(() => {
     const loadTemplates = async () => {
-      if (!campaign) return
+      if (!campaign?.id) return
 
       setLoading(true)
       try {
@@ -329,7 +329,8 @@ export default function GMCTemplatesPage() {
     }
 
     loadTemplates()
-  }, [campaign, client, toastError])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [campaign?.id])
 
   const handleSelectTemplate = async (template: Character) => {
     if (creatingFrom) return // Prevent double-clicking


### PR DESCRIPTION
## Summary
- Fix duplicate API requests occurring on `/characters/gmc` page
- Change useEffect dependencies to only track `campaign?.id` instead of `campaign`, `client`, and `toastError`

## Problem
The GMC template page was making duplicate requests for each character type because:
- `client` object reference changes on re-renders
- `toastError` function reference may change
- Each dependency change triggered the entire effect to re-run, fetching all 5 character types again

## Solution
Updated the useEffect dependency array from `[campaign, client, toastError]` to `[campaign?.id]` with an eslint-disable comment for the intentionally excluded dependencies.

This ensures the effect only re-runs when the actual campaign changes, not when function references change.

## Testing
✅ Verified in production that duplicate requests are eliminated
✅ Page still loads all 5 GMC types correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)