### PR TITLE
fix: Address PR review comments for AI generation toggle

### DIFF
--- a/src/components/campaigns/Show.tsx
+++ b/src/components/campaigns/Show.tsx
@@ -173,23 +173,28 @@ export default function Show({ campaign: initialCampaign }: ShowProperties) {
               control={
                 <Switch
                   checked={campaign.ai_generation_enabled !== false}
-                  onChange={e => {
+                  onChange={async e => {
                     const newValue = e.target.checked
-                    handleChangeAndSave({
-                      target: {
-                        name: "ai_generation_enabled",
-                        value: newValue,
-                      },
-                    })
-                    // Update global campaign context so other components see the change
-                    updateCampaign({ ai_generation_enabled: newValue })
+                    try {
+                      await handleChangeAndSave({
+                        target: {
+                          name: "ai_generation_enabled",
+                          value: newValue,
+                        },
+                      })
+                      // Update global campaign context only after successful API save
+                      updateCampaign({ ai_generation_enabled: newValue })
+                    } catch {
+                      // API save failed, don't update local state
+                    }
                   }}
                 />
               }
               label="AI Generation"
             />
             <Typography variant="body2" color="text.secondary" sx={{ ml: 4.5 }}>
-              Allow AI-powered character and image generation for this campaign
+              Allow AI-powered character and image generation. When disabled,
+              Generate buttons and Extend options are hidden from the UI.
             </Typography>
           </Box>
           <BatchImageGenerationButton campaign={campaign} />

--- a/src/components/characters/GeneratePage.tsx
+++ b/src/components/characters/GeneratePage.tsx
@@ -168,6 +168,7 @@ export default function GeneratePage() {
   }
 
   // Show disabled message when AI generation is turned off
+  // SpeedDial is kept for navigation to other character creation options
   if (!aiEnabled) {
     return (
       <Box sx={{ mx: "auto", mt: 4, position: "relative" }}>

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -265,8 +265,8 @@ export function AppProvider({ children, initialUser }: AppProviderProperties) {
     [client, state.user.id]
   )
 
-  // Optimistically update campaign state in the global context.
-  // Used with API calls (e.g., handleChangeAndSave) to sync UI state after successful saves.
+  // Update campaign state in the global context after successful API save.
+  // Used to sync global UI state with form state changes.
   // Also persists to localStorage for consistency across navigation.
   const updateCampaign = useCallback(
     (updates: Partial<Campaign>) => {

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -265,8 +265,9 @@ export function AppProvider({ children, initialUser }: AppProviderProperties) {
     [client, state.user.id]
   )
 
-  // Update campaign state locally without API call
-  // Also updates localStorage cache to ensure consistency across navigation
+  // Optimistically update campaign state in the global context.
+  // Used with API calls (e.g., handleChangeAndSave) to sync UI state after successful saves.
+  // Also persists to localStorage for consistency across navigation.
   const updateCampaign = useCallback(
     (updates: Partial<Campaign>) => {
       setCampaign(prev => {


### PR DESCRIPTION
## Summary
Follow-up fixes for PR #167 review comments that were addressed but not committed before merge.

- Fix optimistic update race condition in Show.tsx by awaiting API save before updating context
- Update description text to mention UI impact when AI is disabled
- Add comment explaining SpeedDial is kept for navigation on GeneratePage
- Clarify updateCampaign comment in AppContext

## Changes
- `src/components/campaigns/Show.tsx` - Async onChange, try/catch for API errors, updated description
- `src/components/characters/GeneratePage.tsx` - Added explanatory comment
- `src/contexts/AppContext.tsx` - Clearer documentation comment