### PR TITLE
fix: pass legacy-peer-deps flag to npm ci in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Copy dependency files
-COPY package.json package-lock.json* ./
-RUN npm ci
+COPY package.json package-lock.json* .npmrc ./
+RUN npm ci --legacy-peer-deps
 
 # Rebuild the source code only when needed
 FROM base AS builder


### PR DESCRIPTION
This fix ensures Docker builds can properly install dependencies with legacy peer deps flag, allowing the deployment to succeed with the updated dependency tree.